### PR TITLE
fix: get the proxy URL from environment variables in obs client

### DIFF
--- a/openstack/obs/conf.go
+++ b/openstack/obs/conf.go
@@ -341,6 +341,8 @@ func (conf *config) getTransport() error {
 				return err
 			}
 			conf.transport.Proxy = http.ProxyURL(proxyURL)
+		} else {
+			conf.transport.Proxy = http.ProxyFromEnvironment
 		}
 
 		tlsConfig := &tls.Config{InsecureSkipVerify: !conf.sslVerify}


### PR DESCRIPTION
ProxyFromEnvironment returns the URL of the proxy to use for a
given request, as indicated by the environment variables
HTTP_PROXY, HTTPS_PROXY and NO_PROXY (or the lowercase versions
thereof). HTTPS_PROXY takes precedence over HTTP_PROXY for https
requests.

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
