### PR TITLE
feat(api/publish): add publish management sdk support

### DIFF
--- a/openstack/apigw/v2/apis/results.go
+++ b/openstack/apigw/v2/apis/results.go
@@ -352,3 +352,67 @@ func ExtractApis(r pagination.Page) ([]APIResp, error) {
 type DeleteResult struct {
 	golangsdk.ErrResult
 }
+
+// PublishResult represents a result of the Publish method.
+type PublishResult struct {
+	commonResult
+}
+
+// PublishResp is a struct that represents the result of extract operation.
+type PublishResp struct {
+	// Publication record ID.
+	PublishId string `json:"publish_id"`
+	// API ID.
+	ApiId string `json:"api_id"`
+	// API name.
+	ApiName string `json:"api_name"`
+	// ID of the environment in which the API has been published.
+	EnvId string `json:"env_id"`
+	// Description about the publication.
+	Description string `json:"remark"`
+	// Publication time.
+	PublishTime string `json:"publish_time"`
+	// API version currently in use.
+	VersionId string `json:"version_id"`
+}
+
+// Extract is a method to extract an struct of publish response.
+func (r PublishResult) Extract() (*PublishResp, error) {
+	var s PublishResp
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// PublishHistoriesPage represents the publish history pages of the ListPublishHistories operation.
+type PublishHistoriesPage struct {
+	pagination.SinglePageBase
+}
+
+// ApiVersionInfo is a struct that represents the result of ExtractHistories operation.
+type ApiVersionInfo struct {
+	// API version ID.
+	VersionId string `json:"version_id"`
+	// API version.
+	Version string `json:"version_no"`
+	// API ID.
+	ApiId string `json:"api_id"`
+	// ID of the environment in which the API has been published.
+	EnvId string `json:"env_id"`
+	// Name of the environment in which the API has been published.
+	EnvName string `json:"env_name"`
+	// Description about the publication.
+	Description string `json:"remark"`
+	// Publication time.
+	PublishTime string `json:"publish_time"`
+	// Version status.
+	// 1: effective
+	// 2: not effective
+	Status int `json:"status"`
+}
+
+// ExtractHistories is a method which to extract the response to a version information list.
+func ExtractHistories(r pagination.Page) ([]ApiVersionInfo, error) {
+	var s []ApiVersionInfo
+	err := r.(PublishHistoriesPage).Result.ExtractIntoSlicePtr(&s, "api_versions")
+	return s, err
+}

--- a/openstack/apigw/v2/apis/testing/fixtures.go
+++ b/openstack/apigw/v2/apis/testing/fixtures.go
@@ -153,6 +153,50 @@ const (
 		}
 	]
 }`
+
+	expectedPublishAPIResponse = `
+{
+	"api_id": "2b0253cba7d348f698de45abacd3ae29",
+	"env_id": "c5b32727186c4fe6b60408a8a297be09",
+	"publish_id": "8ecdb96299a64e10ad1c7f37a5d24bdb",
+	"publish_time": "2021-10-12T07:02:12.72743121Z",
+	"remark": "Version 1",
+	"version_id": "eaf45032b6a649349cfbfe736d41a711"
+}`
+
+	expectedListPublishHistoriesResponse = `
+{
+	"api_versions": [
+		{
+			"api_id": "2b0253cba7d348f698de45abacd3ae29",
+			"env_id": "c5b32727186c4fe6b60408a8a297be09",
+			"env_name": "tf_lance_apig_environment_demo",
+			"publish_time": "2021-10-12T07:02:12Z",
+			"remark": "Version 1",
+			"status": 1,
+			"version_id": "eaf45032b6a649349cfbfe736d41a711",
+			"version_no": "20211012150212"
+		}
+	]
+}`
+
+	expectedVersionSwitchResponse = `
+{
+	"api_id": "2b0253cba7d348f698de45abacd3ae29",
+	"env_id": "c5b32727186c4fe6b60408a8a297be09",
+	"publish_id": "b8a167517eca451f9f0a68d1e7ee96b8",
+	"publish_time": "2021-10-12T07:37:00.212793535Z",
+	"remark": "Version 1",
+	"version_id": "eaf45032b6a649349cfbfe736d41a711"
+}`
+
+	expectedOfflineAPIResponse = `
+{
+	"api_id": "2b0253cba7d348f698de45abacd3ae29",
+	"env_id": "c5b32727186c4fe6b60408a8a297be09",
+	"api_name": "tf_lance_apig_api_demo",
+	"publish_time": "0001-01-01T00:00:00Z"
+}`
 )
 
 var (
@@ -326,6 +370,59 @@ var (
 			UpdateTime:   "2021-08-05T03:33:35Z",
 		},
 	}
+
+	publishOpts = apis.PublishOpts{
+		Action:      "online",
+		ApiId:       "2b0253cba7d348f698de45abacd3ae29",
+		EnvId:       "c5b32727186c4fe6b60408a8a297be09",
+		Description: "Version 1",
+	}
+
+	expectedPublishResponseData = &apis.PublishResp{
+		ApiId:       "2b0253cba7d348f698de45abacd3ae29",
+		EnvId:       "c5b32727186c4fe6b60408a8a297be09",
+		PublishId:   "8ecdb96299a64e10ad1c7f37a5d24bdb",
+		PublishTime: "2021-10-12T07:02:12.72743121Z",
+		Description: "Version 1",
+		VersionId:   "eaf45032b6a649349cfbfe736d41a711",
+	}
+
+	listPublishHistoriesOpts = apis.ListPublishHistoriesOpts{}
+
+	expectedListPublishHistoriesResponseData = []apis.ApiVersionInfo{
+		{
+			ApiId:       "2b0253cba7d348f698de45abacd3ae29",
+			EnvId:       "c5b32727186c4fe6b60408a8a297be09",
+			EnvName:     "tf_lance_apig_environment_demo",
+			PublishTime: "2021-10-12T07:02:12Z",
+			Description: "Version 1",
+			Status:      1,
+			VersionId:   "eaf45032b6a649349cfbfe736d41a711",
+			Version:     "20211012150212",
+		},
+	}
+
+	expectedVersionSwitchResponseData = &apis.PublishResp{
+		ApiId:       "2b0253cba7d348f698de45abacd3ae29",
+		EnvId:       "c5b32727186c4fe6b60408a8a297be09",
+		PublishId:   "b8a167517eca451f9f0a68d1e7ee96b8",
+		PublishTime: "2021-10-12T07:37:00.212793535Z",
+		Description: "Version 1",
+		VersionId:   "eaf45032b6a649349cfbfe736d41a711",
+	}
+
+	offlineOpts = apis.PublishOpts{
+		Action: "offline",
+		ApiId:  "2b0253cba7d348f698de45abacd3ae29",
+		EnvId:  "c5b32727186c4fe6b60408a8a297be09",
+	}
+
+	expectedOfflineAPIResponseData = &apis.PublishResp{
+		ApiId:       "2b0253cba7d348f698de45abacd3ae29",
+		EnvId:       "c5b32727186c4fe6b60408a8a297be09",
+		ApiName:     "tf_lance_apig_api_demo",
+		PublishTime: "0001-01-01T00:00:00Z",
+	}
 )
 
 func handleV2APICreate(t *testing.T) {
@@ -379,5 +476,49 @@ func handleV2APIDelete(t *testing.T) {
 			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 			w.Header().Add("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNoContent)
+		})
+}
+
+func handleV2APIPublish(t *testing.T) {
+	th.Mux.HandleFunc("/instances/33fc92ffb7e749df952ecc7729d972bc/apis/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedPublishAPIResponse)
+		})
+}
+
+func handleV2APIVersionSwitch(t *testing.T) {
+	th.Mux.HandleFunc("/instances/33fc92ffb7e749df952ecc7729d972bc/apis/publish/2b0253cba7d348f698de45abacd3ae29",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "PUT")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedVersionSwitchResponse)
+		})
+}
+
+func handleV2APIListPublishHistories(t *testing.T) {
+	th.Mux.HandleFunc("/instances/33fc92ffb7e749df952ecc7729d972bc/apis/publish/2b0253cba7d348f698de45abacd3ae29",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "GET")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = fmt.Fprint(w, expectedListPublishHistoriesResponse)
+		})
+}
+
+func handleV2APIOffline(t *testing.T) {
+	th.Mux.HandleFunc("/instances/33fc92ffb7e749df952ecc7729d972bc/apis/action",
+		func(w http.ResponseWriter, r *http.Request) {
+			th.TestMethod(t, r, "POST")
+			th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+			w.Header().Add("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = fmt.Fprint(w, expectedOfflineAPIResponse)
 		})
 }

--- a/openstack/apigw/v2/apis/testing/requests_test.go
+++ b/openstack/apigw/v2/apis/testing/requests_test.go
@@ -63,3 +63,49 @@ func TestDeleteV2API(t *testing.T) {
 		"cded6d80fc9f442c9842eaf854f10525").ExtractErr()
 	th.AssertNoErr(t, err)
 }
+
+func TestPublishV2API(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2APIPublish(t)
+
+	actual, err := apis.Publish(client.ServiceClient(), "33fc92ffb7e749df952ecc7729d972bc",
+		publishOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedPublishResponseData, actual)
+}
+
+func TestVersionSwitchV2API(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2APIVersionSwitch(t)
+
+	actual, err := apis.SwitchSpecVersion(client.ServiceClient(), "33fc92ffb7e749df952ecc7729d972bc",
+		"2b0253cba7d348f698de45abacd3ae29", "eaf45032b6a649349cfbfe736d41a711").Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedVersionSwitchResponseData, actual)
+}
+
+func TestListPublishHistoriesV2API(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2APIListPublishHistories(t)
+
+	pages, err := apis.ListPublishHistories(client.ServiceClient(), "33fc92ffb7e749df952ecc7729d972bc",
+		"2b0253cba7d348f698de45abacd3ae29", listPublishHistoriesOpts).AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := apis.ExtractHistories(pages)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListPublishHistoriesResponseData, actual)
+}
+
+func TestOfflineV2API(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV2APIOffline(t)
+
+	actual, err := apis.Publish(client.ServiceClient(), "33fc92ffb7e749df952ecc7729d972bc",
+		offlineOpts).Extract()
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedOfflineAPIResponseData, actual)
+}

--- a/openstack/apigw/v2/apis/urls.go
+++ b/openstack/apigw/v2/apis/urls.go
@@ -19,3 +19,19 @@ func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
 func resourceURL(c *golangsdk.ServiceClient, instanceId, apiId string) string {
 	return c.ServiceURL(buildRootPath(instanceId), apiId)
 }
+
+func releaseURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), "action")
+}
+
+func batchPublishURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), "publish")
+}
+
+func publishVersionURL(c *golangsdk.ServiceClient, instanceId, apiId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), "publish", apiId)
+}
+
+func showHistoryDetailURL(c *golangsdk.ServiceClient, instanceId, versionId string) string {
+	return c.ServiceURL(buildRootPath(instanceId), "version", versionId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
To support the resource of the API publishment, I provide some SDK methods.

**Which issue this PR fixes*
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. Add some methods of the API publish management:
  a. Publish
  b. SwitchSpecVersion
  c. ListPublishHistories
```

## Acceptance Steps Performed

```
go test -v -run Test
=== RUN   TestCreateV2API
--- PASS: TestCreateV2API (0.00s)
=== RUN   TestGetV2API
--- PASS: TestGetV2API (0.00s)
=== RUN   TestListV2API
--- PASS: TestListV2API (0.00s)
=== RUN   TestUpdateV2API
--- PASS: TestUpdateV2API (0.00s)
=== RUN   TestDeleteV2API
--- PASS: TestDeleteV2API (0.00s)
=== RUN   TestPublishV2API
--- PASS: TestPublishV2API (0.00s)
=== RUN   TestVersionSwitchV2API
--- PASS: TestVersionSwitchV2API (0.00s)
=== RUN   TestListPublishHistoriesV2API
--- PASS: TestListPublishHistoriesV2API (0.00s)
=== RUN   TestOfflineV2API
--- PASS: TestOfflineV2API (0.00s)
PASS
ok      github.com/chnsz/golangsdk/openstack/apigw/v2/apis/testing      0.031s
```