### PR TITLE
feat(dli/sql database): add new database sdk support

### DIFF
--- a/openstack/dli/v1/databases/requests.go
+++ b/openstack/dli/v1/databases/requests.go
@@ -1,0 +1,105 @@
+package databases
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+)
+
+// CreateOpts is a structure which allows to create a new database using given parameters.
+type CreateOpts struct {
+	// Name of the created database.
+	// NOTE: The default database is a built-in database. You cannot create a database named default.
+	Name string `json:"database_name" required:"true"`
+	// Information about the created database.
+	Description string `json:"description,omitempty"`
+	// Enterprise project ID. The value 0 indicates the default enterprise project.
+	// NOTE: Users who have enabled Enterprise Management can set this parameter to bind a specified project.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+	// Database tag.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+// Create is a method to create a new database by CreateOpts.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*RequestResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(rootURL(c), b, &rst.Body, nil)
+	if err == nil {
+		var r RequestResp
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// ListOpts is a structure which allows to obtain databases using given parameters.
+type ListOpts struct {
+	// Specifies whether to display the permission information. The value can be true or false.
+	// The default value is false.
+	IsDesplay bool `q:"with-priv"`
+	// The value should be no less than 0. The default value is 0.
+	Offset int `q:"offset"`
+	// Number of returned data records. The value must be greater than or equal to 0.
+	// By default, all data records are returned.
+	Limit int `q:"limit"`
+	// Database name filtering keyword. Fuzzy match is used to obtain all databases whose names contain the keyword.
+	Keyword string `q:"keyword"`
+	// Database tag. The format is key=value, for example:
+	// GET /v1.0/{project_id}/databases?offset=0&limit=10&with-priv=true&tags=foo%3Dbar
+	// In the preceding information, = needs to be escaped to %3D, foo indicates the tag key, and bar indicates the tag
+	// value.
+	Tags string `q:"tags"`
+}
+
+// List is a method to obtain a list of databases by ListOpts.
+func List(c *golangsdk.ServiceClient, opts ListOpts) (*ListResp, error) {
+	url := rootURL(c)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var rst golangsdk.Result
+	_, err = c.Get(url, &rst.Body, nil)
+	if err == nil {
+		var r ListResp
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// UpdateDBOwnerOpts is a structure which allows to update database owner using given name.
+type UpdateDBOwnerOpts struct {
+	// Name of the new owner. The new user must be a sub-user of the current tenant.
+	NewOwner string `json:"new_owner" required:"true"`
+}
+
+// UpdateDBOwner is a method to update database owner by UpdateDBOwnerOpts.
+func UpdateDBOwner(c *golangsdk.ServiceClient, dbName string, opts UpdateDBOwnerOpts) (*RequestResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(userURL(c, dbName), b, &rst.Body, nil)
+	if err == nil {
+		var r RequestResp
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// Delete is a method to remove the exist database by database name.
+func Delete(c *golangsdk.ServiceClient, dbName string) *golangsdk.ErrResult {
+	var r golangsdk.ErrResult
+	_, r.Err = c.Delete(resourceURL(c, dbName), nil)
+	return &r
+}

--- a/openstack/dli/v1/databases/results.go
+++ b/openstack/dli/v1/databases/results.go
@@ -1,0 +1,41 @@
+package databases
+
+// RequestResp is a object that represents the result of Create and UpdateDBOwner operation.
+type RequestResp struct {
+	// Whether the request is successfully executed. Value true indicates that the request is successfully executed.
+	IsSuccess bool `json:"is_success"`
+	// System prompt. If execution succeeds, the parameter setting may be left blank.
+	Message string `json:"message"`
+}
+
+// ListResp is a object that represents the result of List operation.
+type ListResp struct {
+	// Indicates whether the request is successfully executed.
+	// Value true indicates that the request is successfully executed.
+	IsSuccess bool `json:"is_success"`
+	// System prompt. If execution succeeds, the parameter setting may be left blank.
+	Message string `json:"message"`
+	// Total number of databases.
+	DatabaseCount int `json:"database_count"`
+	// Database information.
+	Databases []Database `json:"databases"`
+}
+
+// Database is a object that represents the database detail.
+type Database struct {
+	// Name of a database.
+	Name string `json:"database_name"`
+	// Creator of a database.
+	Owner string `json:"owner"`
+	// Number of tables in a database.
+	TableNumber int `json:"table_number"`
+	// Information about a database.
+	Description string `json:"description"`
+	// Whether database is shared.
+	IsShared bool `json:"is_shared"`
+	// Enterprise project ID. The value 0 indicates the default enterprise project.
+	// NOTE: Users who have enabled Enterprise Management can set this parameter to bind a specified project.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Resource ID.
+	ResourceId string `json:"resource_id"`
+}

--- a/openstack/dli/v1/databases/testing/fixtures.go
+++ b/openstack/dli/v1/databases/testing/fixtures.go
@@ -1,0 +1,105 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v1/databases"
+	th "github.com/chnsz/golangsdk/testhelper"
+	"github.com/chnsz/golangsdk/testhelper/client"
+)
+
+const (
+	expectedCreateResponse = `
+	{
+		"is_success": true
+	}`
+
+	expectedListResponse = `
+{
+	"database_count": 1,
+	"databases": [
+		{
+			"database_name": "terraform_test",
+			"description": "Created by terraform",
+			"enterprise_project_id": "e9ee3f48-f097-406a-aa74-cfece0af3e31",
+			"is_shared": false,
+			"owner": "terraform",
+			"resource_id": "e766d389-d73f-45e7-af79-29445c36339b",
+			"table_number": 0
+		}
+	],
+	"is_success": true
+}`
+)
+
+var (
+	createOpts = databases.CreateOpts{
+		Name:                "terraform_test",
+		EnterpriseProjectId: "e9ee3f48-f097-406a-aa74-cfece0af3e31",
+	}
+
+	expectedCreateResponseData = &databases.RequestResp{
+		IsSuccess: true,
+	}
+
+	expectedListResponseData = &databases.ListResp{
+		DatabaseCount: 1,
+		Databases: []databases.Database{
+			{
+				Name:                "terraform_test",
+				Description:         "Created by terraform",
+				EnterpriseProjectId: "e9ee3f48-f097-406a-aa74-cfece0af3e31",
+				IsShared:            false,
+				Owner:               "terraform",
+				ResourceId:          "e766d389-d73f-45e7-af79-29445c36339b",
+				TableNumber:         0,
+			},
+		},
+		IsSuccess: true,
+	}
+
+	updateDBOwnerOpts = databases.UpdateDBOwnerOpts{
+		NewOwner: "newOwner",
+	}
+)
+
+func handleV1DatabaseCreate(t *testing.T) {
+	th.Mux.HandleFunc("/databases", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedCreateResponse)
+	})
+}
+
+func handleV1DatabaseList(t *testing.T) {
+	th.Mux.HandleFunc("/databases", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedListResponse)
+	})
+}
+
+func handleV1DatabaseOwnerUpdate(t *testing.T) {
+	th.Mux.HandleFunc("/databases/terraform_test/owner", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PUT")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, expectedCreateResponse)
+	})
+}
+
+func handleV1DatabaseDelete(t *testing.T) {
+	th.Mux.HandleFunc("/databases/terraform_test", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+	})
+}

--- a/openstack/dli/v1/databases/testing/requests_test.go
+++ b/openstack/dli/v1/databases/testing/requests_test.go
@@ -1,0 +1,48 @@
+package testing
+
+import (
+	"testing"
+
+	"github.com/chnsz/golangsdk/openstack/dli/v1/databases"
+	th "github.com/chnsz/golangsdk/testhelper"
+	"github.com/chnsz/golangsdk/testhelper/client"
+)
+
+func TestCreateV1Database(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV1DatabaseCreate(t)
+
+	actual, err := databases.Create(client.ServiceClient(), createOpts)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestListV1Database(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV1DatabaseList(t)
+
+	actual, err := databases.List(client.ServiceClient(), databases.ListOpts{})
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedListResponseData, actual)
+}
+
+func TestUpdateV1DatabaseOwner(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV1DatabaseOwnerUpdate(t)
+
+	actual, err := databases.UpdateDBOwner(client.ServiceClient(), "terraform_test", updateDBOwnerOpts)
+	th.AssertNoErr(t, err)
+	th.AssertDeepEquals(t, expectedCreateResponseData, actual)
+}
+
+func TestDeleteV1Database(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	handleV1DatabaseDelete(t)
+
+	err := databases.Delete(client.ServiceClient(), "terraform_test").ExtractErr()
+	th.AssertNoErr(t, err)
+}

--- a/openstack/dli/v1/databases/urls.go
+++ b/openstack/dli/v1/databases/urls.go
@@ -1,0 +1,17 @@
+package databases
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "databases"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, dbName string) string {
+	return c.ServiceURL(rootPath, dbName)
+}
+
+func userURL(c *golangsdk.ServiceClient, dbName string) string {
+	return c.ServiceURL(rootPath, dbName, "owner")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

For DLI service, add a new SQL database sdk support:
- Create a new database
- Obtain a database list
- Update database owner
- Delete database

**Which issue this PR fixes**

```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. add new database sdk support.
```

## Acceptance Steps Performed

```
go test -v -run Test
=== RUN   TestCreateV1Database
--- PASS: TestCreateV1Database (0.00s)
=== RUN   TestListV1Database
--- PASS: TestListV1Database (0.00s)
=== RUN   TestUpdateV1DatabaseOwner
--- PASS: TestUpdateV1DatabaseOwner (0.00s)
=== RUN   TestDeleteV1Database
--- PASS: TestDeleteV1Database (0.00s)
PASS
ok      github.com/chnsz/golangsdk/openstack/dli/v1/databases/testing   0.015s
```