### PR TITLE
feat(waf/pools): add sdk for WAF pools

### DIFF
--- a/openstack/waf_hw/v1/pools/requests.go
+++ b/openstack/waf_hw/v1/pools/requests.go
@@ -1,0 +1,168 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package pools
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+var RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// CreateOpts the options for creating pools.
+type CreateOpts struct {
+	Name        string `json:"name" required:"true"`
+	Region      string `json:"region" required:"true"`
+	Type        string `json:"type" required:"true"`
+	VpcID       string `json:"vpc_id" required:"true"`
+	Description string `json:"description,omitempty"`
+}
+
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*PoolSummaryDetail, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(rootURL(c), b, &rst.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r PoolSummaryDetail
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+func Get(c *golangsdk.ServiceClient, poolID string) (*Pool, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, poolID), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r Pool
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+type ListPoolOpts struct {
+	Name     string `q:"name"`
+	VpcID    string `q:"vpc_id"`
+	Detail   bool   `q:"detail"`
+	Page     string `q:"page"`
+	PageSize string `q:"pagesize"`
+}
+
+func List(c *golangsdk.ServiceClient, opts ListPoolOpts) (*pagination.Pager, error) {
+	url := rootURL(c)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	page := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := PoolPage{pagination.PageSizeBase{PageResult: r}}
+		return p
+	})
+
+	return &page, nil
+}
+
+type UpdatePoolOpts struct {
+	Name        string      `json:"name,omitempty"`
+	Option      *PoolOption `json:"option,omitempty"`
+	Description *string     `json:"description,omitempty"`
+}
+
+type PoolOption struct {
+	BodyLimit      int `json:"body_limit,omitempty"`
+	HeaderLimit    int `json:"header_limit,omitempty"`
+	ConnectTimeout int `json:"connect_timeout,omitempty"`
+	SendTimeout    int `json:"send_timeout,omitempty"`
+	ReadTimeout    int `json:"read_timeout,omitempty"`
+}
+
+func Update(c *golangsdk.ServiceClient, poolID string, opts UpdatePoolOpts) (*Pool, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(resourceURL(c, poolID), b, &rst.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r Pool
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+func Delete(c *golangsdk.ServiceClient, poolID string) (*PoolSummaryDetail, error) {
+	var rst golangsdk.Result
+	_, err := c.DeleteWithResponse(resourceURL(c, poolID), &rst.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r PoolSummaryDetail
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+type addLBOpts struct {
+	LoadBalancerID string `json:"loadbalancer_id" required:"true"`
+}
+
+func AddELB(c *golangsdk.ServiceClient, poolID, loadBalancerID string) (*PoolBinding, error) {
+	opts := addLBOpts{LoadBalancerID: loadBalancerID}
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(bindingURL(c, poolID), b, &rst.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	if err == nil {
+		var r PoolBinding
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+func RemoveELB(c *golangsdk.ServiceClient, poolID, bindingID string) error {
+	_, err := c.Delete(bindingResourceURL(c, poolID, bindingID), &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders,
+	})
+	return err
+}
+
+func ListELB(c *golangsdk.ServiceClient, poolID string) pagination.Pager {
+	url := bindingURL(c, poolID)
+
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := BindELBPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	})
+}

--- a/openstack/waf_hw/v1/pools/results.go
+++ b/openstack/waf_hw/v1/pools/results.go
@@ -1,0 +1,91 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package pools
+
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+type PoolSummaryDetail struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Region      string `json:"region"`
+	Type        string `json:"type"`
+	VpcID       string `json:"vpc_id"`
+	Description string `json:"description"`
+}
+
+type Pool struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Region      string `json:"region"`
+	VpcID       string `json:"vpc_id"`
+	Description string `json:"description"`
+
+	Option    PoolOption    `json:"option"`
+	Hosts     []IDNameEntry `json:"hosts"`
+	Instances []IDNameEntry `json:"instances"`
+	Bindings  []IDNameEntry `json:"bindings"`
+}
+
+type IDNameEntry struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type PoolBinding struct {
+	ID             string `json:"id"`
+	LoadBalancerID string `json:"loadbalancer_id"`
+	WafPoolID      string `json:"waf_pool_id"`
+}
+
+type PoolPage struct {
+	pagination.PageSizeBase
+}
+
+// IsEmpty checks whether a RouteTablePage struct is empty.
+func (b PoolPage) IsEmpty() (bool, error) {
+	arr, err := ExtractGroups(b)
+	return len(arr) == 0, err
+}
+
+func ExtractGroups(r pagination.Page) ([]Pool, error) {
+	var s struct {
+		Total int    `json:"total"`
+		Items []Pool `json:"items"`
+	}
+	err := (r.(PoolPage)).ExtractInto(&s)
+	return s.Items, err
+}
+
+type BindELBPage struct {
+	pagination.MarkerPageBase
+}
+
+// LastMarker returns the last route table ID in a ListResult
+func (b BindELBPage) LastMarker() (string, error) {
+	elbs, err := ExtractBindELBs(b)
+	if err != nil {
+		return "", err
+	}
+	if len(elbs) == 0 {
+		return "", nil
+	}
+	return elbs[len(elbs)-1].ID, nil
+}
+
+// IsEmpty checks whether a RouteTablePage struct is empty.
+func (b BindELBPage) IsEmpty() (bool, error) {
+	elbs, err := ExtractBindELBs(b)
+	return len(elbs) == 0, err
+}
+
+func ExtractBindELBs(r pagination.Page) ([]PoolBinding, error) {
+	var s struct {
+		Results []PoolBinding `json:"results"`
+	}
+	err := (r.(BindELBPage)).ExtractInto(&s)
+	return s.Results, err
+}

--- a/openstack/waf_hw/v1/pools/urls.go
+++ b/openstack/waf_hw/v1/pools/urls.go
@@ -1,0 +1,23 @@
+/*
+ Copyright (c) Huawei Technologies Co., Ltd. 2021. All rights reserved.
+*/
+
+package pools
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("pool")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, poolID string) string {
+	return c.ServiceURL("pool", poolID)
+}
+
+func bindingURL(c *golangsdk.ServiceClient, poolID string) string {
+	return c.ServiceURL("pool", poolID, "bindings")
+}
+
+func bindingResourceURL(c *golangsdk.ServiceClient, poolID, elbID string) string {
+	return c.ServiceURL("pool", poolID, "bindings", elbID)
+}

--- a/pagination/pagesize.go
+++ b/pagination/pagesize.go
@@ -1,0 +1,59 @@
+package pagination
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// PageSizeBase is used for paging queries based on "page" and "pageSize".
+// You can change the parameter name of the current page number by overriding the GetPageName method.
+type PageSizeBase struct {
+	PageResult
+}
+
+// GetPageName Overwrite this function for changing the parameter name of the current page number
+// Default value is "page"
+func (current PageSizeBase) GetPageName() string {
+	return "page"
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (current PageSizeBase) NextPageURL() (string, error) {
+	currentURL := current.URL
+
+	q := currentURL.Query()
+	pageNum := q.Get(current.GetPageName())
+	if pageNum == "" {
+		pageNum = "1"
+	}
+
+	sizeVal, err := strconv.ParseInt(pageNum, 10, 32)
+	if err != nil {
+		return "", err
+	}
+
+	pageNum = strconv.Itoa(int(sizeVal + 1))
+	q.Set(current.GetPageName(), pageNum)
+	currentURL.RawQuery = q.Encode()
+	return currentURL.String(), nil
+}
+
+// IsEmpty satisifies the IsEmpty method of the Page interface
+func (current PageSizeBase) IsEmpty() (bool, error) {
+	if b, ok := current.Body.([]interface{}); ok {
+		return len(b) == 0, nil
+	}
+	err := golangsdk.ErrUnexpectedType{}
+	err.Expected = "[]interface{}"
+	err.Actual = fmt.Sprintf("%v", reflect.TypeOf(current.Body))
+	return true, err
+}
+
+// GetBody returns the linked page's body. This method is needed to satisfy the
+// Page interface.
+func (current PageSizeBase) GetBody() interface{} {
+	return current.Body
+}


### PR DESCRIPTION
Add sdk for WAF pools.
- Supports adding, obtaining, updating, and deleting groups of WAF instances.
- Supports adding and deleting ELB instances in the WAF instance group.