### PR TITLE
fix(dis): add region to header when using aksk authentication

### DIFF
--- a/openstack/dis/v2/streams/requests.go
+++ b/openstack/dis/v2/streams/requests.go
@@ -133,10 +133,6 @@ type CreatePolicyOpt struct {
 	Effect string `json:"effect" required:"true"`
 }
 
-var RequestOpts = golangsdk.RequestOpts{
-	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
-}
-
 func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*golangsdk.Result, error) {
 	b, err := golangsdk.BuildRequestBody(opts, "")
 	if err != nil {
@@ -145,7 +141,10 @@ func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*golangsdk.Result, err
 
 	var r golangsdk.Result
 	_, r.Err = c.Post(rootURL(c), b, nil, &golangsdk.RequestOpts{
-		MoreHeaders: RequestOpts.MoreHeaders,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       c.AKSKAuthOptions.Region,
+		},
 	})
 	return &r, r.Err
 }
@@ -161,7 +160,10 @@ func Get(c *golangsdk.ServiceClient, streamName string, opts GetOpts) (*StreamDe
 
 	var rst StreamDetail
 	_, err = c.Get(url, &rst, &golangsdk.RequestOpts{
-		MoreHeaders: RequestOpts.MoreHeaders,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       c.AKSKAuthOptions.Region,
+		},
 	})
 
 	if err == nil {
@@ -173,7 +175,10 @@ func Get(c *golangsdk.ServiceClient, streamName string, opts GetOpts) (*StreamDe
 func Delete(c *golangsdk.ServiceClient, streamName string) *golangsdk.ErrResult {
 	var r golangsdk.ErrResult
 	_, r.Err = c.Delete(resourceURL(c, streamName), &golangsdk.RequestOpts{
-		MoreHeaders: RequestOpts.MoreHeaders,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       c.AKSKAuthOptions.Region,
+		},
 	})
 	return &r
 }
@@ -187,7 +192,12 @@ func List(c *golangsdk.ServiceClient, opts ListStreamsOpts) (*ListResult, error)
 	url := rootURL(c) + query.String()
 
 	var rst ListResult
-	_, err = c.Get(url, &rst, &golangsdk.RequestOpts{MoreHeaders: RequestOpts.MoreHeaders})
+	_, err = c.Get(url, &rst, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       c.AKSKAuthOptions.Region,
+		},
+	})
 	if err == nil {
 		return &rst, nil
 	}
@@ -202,7 +212,10 @@ func UpdatePartition(c *golangsdk.ServiceClient, name string, opts UpdatePartiti
 
 	var r golangsdk.Result
 	_, err = c.Put(resourceURL(c, name), b, nil, &golangsdk.RequestOpts{
-		MoreHeaders: RequestOpts.MoreHeaders,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       c.AKSKAuthOptions.Region,
+		},
 	})
 	return &r, err
 }
@@ -215,7 +228,10 @@ func CreatePolicy(c *golangsdk.ServiceClient, streamName string, opts CreatePoli
 
 	var r golangsdk.Result
 	_, err = c.Post(policiesURL(c, streamName), b, nil, &golangsdk.RequestOpts{
-		MoreHeaders: RequestOpts.MoreHeaders,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       c.AKSKAuthOptions.Region,
+		},
 	})
 	return &r, err
 }
@@ -223,7 +239,10 @@ func CreatePolicy(c *golangsdk.ServiceClient, streamName string, opts CreatePoli
 func ListPolicies(c *golangsdk.ServiceClient, streamName string) (*ListPolicyResult, error) {
 	var rst ListPolicyResult
 	_, err := c.Get(policiesURL(c, streamName), &rst, &golangsdk.RequestOpts{
-		MoreHeaders: RequestOpts.MoreHeaders,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       c.AKSKAuthOptions.Region,
+		},
 	})
 	if err == nil {
 		return &rst, nil

--- a/openstack/dis/v3/streams/requests.go
+++ b/openstack/dis/v3/streams/requests.go
@@ -14,10 +14,6 @@ type UpdateOpts struct {
 	AutoScaleMaxPartitionCount *int   `json:"auto_scale_max_partition_count,omitempty"`
 }
 
-var RequestOpts = golangsdk.RequestOpts{
-	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
-}
-
 func Update(c *golangsdk.ServiceClient, name string, opts UpdateOpts) (*golangsdk.Result, error) {
 	b, err := golangsdk.BuildRequestBody(opts, "")
 	if err != nil {
@@ -26,7 +22,10 @@ func Update(c *golangsdk.ServiceClient, name string, opts UpdateOpts) (*golangsd
 
 	var r golangsdk.Result
 	_, err = c.Put(UpdateURL(c, name), b, &r.Body, &golangsdk.RequestOpts{
-		MoreHeaders: RequestOpts.MoreHeaders,
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"region":       c.AKSKAuthOptions.Region,
+		},
 	})
 	return &r, err
 }


### PR DESCRIPTION
 when using aksk authentication, should add region to header

**user account Test**
```
make testacc TEST='./huaweicloud/services/acceptance/dis' TESTARGS='-run=TestAccResourceDisStream_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dis -v -run=TestAccResourceDisStream_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDisStream_basic
=== PAUSE TestAccResourceDisStream_basic
=== CONT  TestAccResourceDisStream_basic
--- PASS: TestAccResourceDisStream_basic (36.60s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dis       36.672s
```

**AKSK Test**
```
 make testacc TEST='./huaweicloud/services/acceptance/dis' TESTARGS='-run=TestAccResourceDisStream_basic'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./huaweicloud/services/acceptance/dis -v -run=TestAccResourceDisStream_basic -timeout 360m -parallel 4
=== RUN   TestAccResourceDisStream_basic
=== PAUSE TestAccResourceDisStream_basic
=== CONT  TestAccResourceDisStream_basic
--- PASS: TestAccResourceDisStream_basic (39.38s)
PASS
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/dis       39.463s
```
