### PR TITLE
fix(arg/type): update the type of class name from string to pointer

### DIFF
--- a/openstack/dli/v2/batches/requests.go
+++ b/openstack/dli/v2/batches/requests.go
@@ -7,13 +7,13 @@ type CreateOpts struct {
 	// Name of the package that is of the JAR or pyFile type and has been uploaded to the DLI resource management
 	// system. You can also specify an OBS path, for example, obs://Bucket name/Package name.
 	File string `json:"file" required:"true"`
-	// Java/Spark main class of the batch processing job.
-	ClassName string `json:"class_name" required:"true"`
 	// Queue name. Set this parameter to the name of the created DLI queue.
 	// NOTE: This parameter is compatible with the cluster_name parameter. That is, if cluster_name is used to specify a
 	//       queue, the queue is still valid.
 	// You are advised to use the queue parameter. The queue and cluster_name parameters cannot coexist.
 	Queue string `json:"queue" required:"true"`
+	// Java/Spark main class of the batch processing job.
+	ClassName *string `json:"class_name,omitempty"`
 	// Queue name. Set this parameter to the created DLI queue name.
 	// NOTE: You are advised to use the queue parameter. The queue and cluster_name parameters cannot coexist.
 	ClusterName string `json:"cluster_name,omitempty"`

--- a/openstack/dli/v2/batches/testing/fixtures.go
+++ b/openstack/dli/v2/batches/testing/fixtures.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/openstack/dli/v2/batches"
 	th "github.com/chnsz/golangsdk/testhelper"
 	"github.com/chnsz/golangsdk/testhelper/client"
@@ -33,7 +34,7 @@ const (
 
 var (
 	createOpts = batches.CreateOpts{
-		ClassName: "driver_behavior",
+		ClassName: golangsdk.MaybeString("driver_behavior"),
 		Queue:     "terraform_test",
 		Name:      "terraform_spark_job",
 		Configurations: map[string]interface{}{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Due to the problem of API design, the field of `ClassName` is required for `jars`, `pythons`, and `user files`.
In fact, the two types of `pythons` and `user files` can be left blank, but the API requires that the value must be passed (empty string).
So, the type of `ClassName` must be changed to the optional pointer.

**Which issue this PR fixes**
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. update the type of class name from string to the optional pointer.
```
