### PR TITLE
fix(DLI): add three fileds from job to config

### DIFF
--- a/openstack/dli/v1/flinkjob/results.go
+++ b/openstack/dli/v1/flinkjob/results.go
@@ -180,6 +180,9 @@ type JobConfBase struct {
 	TmSlotNum        int    `json:"tm_slot_num"`
 	ResumeMaxNum     int    `json:"resume_max_num"`
 	CheckpointPath   string `json:"checkpoint_path"`
+	Feature          string `json:"feature"`
+	FlinkVersion     string `json:"flink_version"`
+	Image            string `json:"image"`
 }
 
 type ListResp struct {


### PR DESCRIPTION
Because the documentation does not match the actual return of api, so temporarily add three fileds from job to config.