### PR TITLE
refactor(cci/namespace): update json tag of bool string

### DIFF
--- a/openstack/cci/v1/namespaces/requests.go
+++ b/openstack/cci/v1/namespaces/requests.go
@@ -55,7 +55,7 @@ type Annotations struct {
 	// Currently, GPU-accelerated and general-computing clusters are supported.
 	Flavor string `json:"namespace.kubernetes.io/flavor" required:"true"`
 	// Whether to enable elastic scheduling.
-	AutoExpend string `json:"namespace.kubernetes.io/allowed-on-shared-node,omitempty"`
+	AutoExpend bool `json:"namespace.kubernetes.io/allowed-on-shared-node,string"`
 	// Whether to enable container network.
 	NetworkEnable string `json:"network.cci.io/ready-before-pod-run,omitempty"`
 	// IP Pool Warm-up for Namespace.
@@ -80,7 +80,7 @@ type Pending struct {
 type Labels struct {
 	// Role-based access control (RBAC).
 	// If enabled, access to resources in the namespace will be controlled by RBAC policies.
-	RbacEnable string `json:"rbac.authorization.cci.io/enable-k8s-rbac,omitempty"`
+	RbacEnable bool `json:"rbac.authorization.cci.io/enable-k8s-rbac,string"`
 	// ID of enterprise project.
 	EnterpriseProjectID string `json:"sys_enterprise_project_id,omitempty"`
 }

--- a/openstack/cci/v1/namespaces/results.go
+++ b/openstack/cci/v1/namespaces/results.go
@@ -45,7 +45,7 @@ type MetaResp struct {
 // AnnotationsResp is an object of unstructured key value map.
 type AnnotationsResp struct {
 	// Whether to enable elastic scheduling.
-	AutoExpend string `json:"namespace.kubernetes.io/allowed-on-shared-node"`
+	AutoExpend bool `json:"namespace.kubernetes.io/allowed-on-shared-node,string"`
 	// Flavor of the cluster to which the namespace belongs.
 	Flavor string `json:"namespace.kubernetes.io/flavor"`
 	// Indicates whether to support dynamic storage creation.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For some parameters, their type is bool, but the API requires them to enter a string value and return the same type.
In this case, we can use json automatic parsing instead of manual type conversion.

**Which issue this PR fixes**
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. Update the json tag of the parameter for boolean string type.
```
