### PR TITLE
refactor(cci/namespace): update json tag of integer string

### DIFF
--- a/openstack/cci/v1/namespaces/requests.go
+++ b/openstack/cci/v1/namespaces/requests.go
@@ -59,9 +59,9 @@ type Annotations struct {
 	// Whether to enable container network.
 	NetworkEnable string `json:"network.cci.io/ready-before-pod-run,omitempty"`
 	// IP Pool Warm-up for Namespace.
-	PoolSize string `json:"network.cci.io/warm-pool-size,omitempty"`
+	PoolSize int `json:"network.cci.io/warm-pool-size,omitempty,string"`
 	// IP Address Recycling Interval, in hour.
-	RecyclingInterval string `json:"network.cci.io/warm-pool-recycle-interval,omitempty"`
+	RecyclingInterval int `json:"network.cci.io/warm-pool-recycle-interval,omitempty,string"`
 }
 
 // Initializers is a controller which enforces some system invariant at namespace creation time.

--- a/openstack/cci/v1/namespaces/results.go
+++ b/openstack/cci/v1/namespaces/results.go
@@ -61,9 +61,9 @@ type AnnotationsResp struct {
 	// Whether to enable container network.
 	NetworkEnable string `json:"network.cci.io/ready-before-pod-run"`
 	// IP Pool Warm-up for Namespace.
-	PoolSize string `json:"network.cci.io/warm-pool-size"`
+	PoolSize int `json:"network.cci.io/warm-pool-size,string"`
 	// IP Address Recycling Interval, in hour.
-	RecyclingInterval string `json:"network.cci.io/warm-pool-recycle-interval"`
+	RecyclingInterval int `json:"network.cci.io/warm-pool-recycle-interval,string"`
 }
 
 // CreateResult represents a result of the Create method.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
For some parameters, their type is integer, but the API requires them to enter a string value and return the same type.
In this case, we can use json automatic parsing instead of manual type conversion.

refer to #54 

**Which issue this PR fixes**
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. Update the json tag of the parameter for integer string type.
```
