### PR TITLE
fix(cbr/vaults): update parameter types of the listopts

### DIFF
--- a/openstack/cbr/v3/vaults/requests.go
+++ b/openstack/cbr/v3/vaults/requests.go
@@ -127,10 +127,10 @@ type ListOpts struct {
 	CloudType           string `q:"cloud_type"`
 	EnterpriseProjectID string `q:"enterprise_project_id"`
 	ID                  string `q:"id"`
-	Limit               string `q:"limit"`
+	Limit               int    `q:"limit"`
 	Name                string `q:"name"`
 	ObjectType          string `q:"object_type"`
-	Offset              string `q:"offset"`
+	Offset              int    `q:"offset"`
 	PolicyID            string `q:"policy_id"`
 	ProtectType         string `q:"protect_type"`
 	ResourceIDs         string `q:"resource_ids"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The type of `Limit` and `Offset` parameters of the ListOpts are wrong.

**Which issue this PR fixes**
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. update the parameter types.
```
