### PR TITLE
fix: style: update the cidr of the specification

### DIFF
--- a/openstack/cci/v1/networks/requests.go
+++ b/openstack/cci/v1/networks/requests.go
@@ -37,7 +37,7 @@ type CreateMetaData struct {
 // Specifications to create a network
 type Spec struct {
 	// Network CIDR
-	Cidr string `json:"type,omitempty"`
+	CIDR string `json:"cidr,omitempty"`
 	// Network VPC ID
 	AttachedVPC string `json:"attachedVPC" required:"true"`
 	// Network Type


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The json tag of the CIDR argument is wrong, should be `cidr` string.
The CIDR is an abbreviation of proper nouns, should be `CIDR`, not `Cidr`.

**Which issue this PR fixes**
`NONE`

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. update the json tag of the CIDR.
2. update the argument name's format of the CIDR.
```
