### PR TITLE
fix: readjust json tag of subnet id

### DIFF
--- a/openstack/cci/v1/networks/requests.go
+++ b/openstack/cci/v1/networks/requests.go
@@ -44,10 +44,10 @@ type Spec struct {
 	NetworkType string `json:"networkType" required:"true"`
 	// Network ID
 	NetworkID string `json:"networkID" required:"true"`
-	// Subnet ID
-	SubnetID string `json:"subnetID" required:"true"`
 	// Network AZ
 	AvailableZone string `json:"availableZone" required:"true"`
+	// Subnet ID
+	SubnetID string `json:"subnetID,omitempty"`
 }
 
 // ToNetworkCreateMap builds a create request body from CreateOpts.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Fix the json tag of subnet ID of CCI network request structure.
- from `required` to `optional`

**Which issue this PR fixes**
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. update the json tag of subnet ID.
```
