### PR TITLE
update map value of tags from string to interface

### DIFF
--- a/openstack/evs/v2/cloudvolumes/results.go
+++ b/openstack/evs/v2/cloudvolumes/results.go
@@ -118,7 +118,7 @@ type Volume struct {
 	// Arbitrary key-value pairs defined by the metadata field table.
 	Metadata VolumeMetadata `json:"metadata"`
 	// Arbitrary key-value pairs defined by the user.
-	Tags map[string]string `json:"tags"`
+	Tags map[string]interface{} `json:"tags"`
 	// UserID is the id of the user who created the volume.
 	UserID string `json:"user_id"`
 	// The date when this volume was created.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The type map[string]interface{} cannot compare with type mapp[string]string in function `FilterSliceWithField`.

**Which issue this PR fixes**
```
NONE
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. update map value of tags from string to interface.
```
