### PR TITLE
chore(util): add a custom type: SensitiveString

### DIFF
--- a/openstack/utils/custom_type.go
+++ b/openstack/utils/custom_type.go
@@ -1,0 +1,12 @@
+package utils
+
+// In the function of fmt/log and json.Marshal, all SensitiveString fields will return "******".
+type SensitiveString string
+
+func (s SensitiveString) String() string {
+	return "******"
+}
+
+func (s SensitiveString) MarshalJSON() ([]byte, error) {
+	return []byte(`"******"`), nil
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

add a custom type: SensitiveString, in the function of fmt/log and json.Marshal, all SensitiveString fields will return "******".

```
type SenSt struct {
	B SensitiveString `json:"b"`
	A string          `json:"message"`
}

func Test_Sensitive(t *testing.T) {
	param := SenSt{
		B: "123",
		A: "33",
	}
	dataType, _ := json.Marshal(param)
	dataString := string(dataType)
	
	fmt.Println("fmt.Println, params:", param)
	fmt.Println("fmt.Println, params.B:", param.B)
	fmt.Printf("fmt.Printf,  params.B:%s \n", param.B)
	fmt.Println("json.Marshal, param", dataString)
	log.Printf("log.Printf, params.B:%s \n", param.B)
}

```

```

=== RUN   Test_Sensitive
fmt.Println, params: {****** 33}
fmt.Println, params.B: ******
fmt.Printf,  params.B:******
json.Marshal, param {"b":"******","message":"33"}
2021/12/24 11:46:45 log.Printf, params.B:******
```