### PR TITLE
feat: add dms kafka topics v1 APIs for orange

### DIFF
--- a/openstack/dms/v1/topics/doc.go
+++ b/openstack/dms/v1/topics/doc.go
@@ -1,0 +1,5 @@
+/*
+Package topics is only used by terraform-provider-flexibleengine with
+DmsV1Client to manage flexibleengine_dms_kafka_topic resource.
+*/
+package topics

--- a/openstack/dms/v1/topics/requests.go
+++ b/openstack/dms/v1/topics/requests.go
@@ -1,0 +1,70 @@
+package topics
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// CreateOpsBuilder is an interface which is used for creating a kafka topic
+type CreateOpsBuilder interface {
+	ToTopicCreateMap() (map[string]interface{}, error)
+}
+
+// CreateOps is a struct that contains all the parameters of create function
+type CreateOps struct {
+	// the name/ID of a topic
+	Name string `json:"id" required:"true"`
+	// topic partitions, value range: 1-50, Default value:3
+	Partition int `json:"partition,omitempty"`
+	// topic replications, value range: 1-3, Default value:3
+	Replication int `json:"replication,omitempty"`
+	// aging time in hours, value range: 1-168, , Default value:72
+	RetentionTime int `json:"retention_time,omitempty"`
+
+	SyncMessageFlush bool `json:"sync_message_flush,omitempty"`
+	SyncReplication  bool `json:"sync_replication,omitempty"`
+}
+
+// ToTopicCreateMap is used for type convert
+func (ops CreateOps) ToTopicCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(ops, "")
+}
+
+// Create a kafka topic with given parameters
+func Create(client *golangsdk.ServiceClient, instanceID string, ops CreateOpsBuilder) (r CreateResult) {
+	b, err := ops.ToTopicCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(rootURL(client, instanceID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}
+
+// List all topics belong to the instance id
+func List(client *golangsdk.ServiceClient, instanceID string) (r ListResult) {
+	_, r.Err = client.Get(rootURL(client, instanceID), &r.Body, nil)
+	return
+}
+
+// Delete given topics belong to the instance id
+func Delete(client *golangsdk.ServiceClient, instanceID string, topics []string) (r DeleteResult) {
+	var delOpts = struct {
+		Topics []string `json:"topics" required:"true"`
+	}{Topics: topics}
+
+	b, err := golangsdk.BuildRequestBody(delOpts, "")
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(deleteURL(client, instanceID), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+
+	return
+}

--- a/openstack/dms/v1/topics/results.go
+++ b/openstack/dms/v1/topics/results.go
@@ -1,0 +1,112 @@
+package topics
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/chnsz/golangsdk"
+)
+
+// CreateResponse is a struct that contains the create response
+type CreateResponse struct {
+	Name string `json:"id"`
+}
+
+// Topic includes the parameters of an topic
+type Topic struct {
+	Name             string `json:"id"`
+	Partition        int    `json:"partition"`
+	Replication      int    `json:"replication"`
+	RetentionTime    int    `json:"retention_time"`
+	TopicType        int    `json:"topic_type"`
+	PoliciesOnly     bool   `json:"policiesOnly"`
+	SyncReplication  bool   `json:"-"`
+	SyncMessageFlush bool   `json:"-"`
+}
+
+// UnmarshalJSON to override default
+func (r *Topic) UnmarshalJSON(b []byte) error {
+	type tmp Topic
+	var s struct {
+		tmp
+		SyncReplication  interface{} `json:"sync_replication"`
+		SyncMessageFlush interface{} `json:"sync_message_flush"`
+	}
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+
+	*r = Topic(s.tmp)
+
+	switch t := s.SyncReplication.(type) {
+	case string:
+		enabled, _ := strconv.ParseBool(s.SyncReplication.(string))
+		r.SyncReplication = enabled
+	case bool:
+		r.SyncReplication = t
+	}
+
+	switch t := s.SyncMessageFlush.(type) {
+	case string:
+		enabled, _ := strconv.ParseBool(s.SyncMessageFlush.(string))
+		r.SyncMessageFlush = enabled
+	case bool:
+		r.SyncMessageFlush = t
+	}
+
+	return err
+}
+
+// ListResponse is a struct that contains the list response
+type ListResponse struct {
+	Total            int     `json:"total"`
+	Size             int     `json:"size"`
+	RemainPartitions int     `json:"remain_partitions"`
+	MaxPartitions    int     `json:"max_partitions"`
+	Topics           []Topic `json:"topics"`
+}
+
+// CreateResult is a struct that contains all the return parameters of creation
+type CreateResult struct {
+	golangsdk.Result
+}
+
+// Extract from CreateResult
+func (r CreateResult) Extract() (*CreateResponse, error) {
+	var s CreateResponse
+	err := r.Result.ExtractInto(&s)
+	return &s, err
+}
+
+// ListResult contains the body of getting detailed
+type ListResult struct {
+	golangsdk.Result
+}
+
+// Extract from ListResult
+func (r ListResult) Extract() ([]Topic, error) {
+	var s ListResponse
+	err := r.Result.ExtractInto(&s)
+	return s.Topics, err
+}
+
+// DeleteResult is a struct which contains the result of deletion
+type DeleteResult struct {
+	golangsdk.Result
+}
+
+// DeleteResponse is a struct that contains the deletion response
+type DeleteResponse struct {
+	Name    string `json:"id"`
+	Success bool   `json:"success"`
+}
+
+// Extract from DeleteResult
+func (r DeleteResult) Extract() ([]DeleteResponse, error) {
+	var s struct {
+		Topics []DeleteResponse `json:"topics"`
+	}
+	err := r.Result.ExtractInto(&s)
+	return s.Topics, err
+}

--- a/openstack/dms/v1/topics/urls.go
+++ b/openstack/dms/v1/topics/urls.go
@@ -1,0 +1,20 @@
+package topics
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+const (
+	resourcePath = "instances"
+	topicPath    = "topics"
+)
+
+// rootURL will build the url of create, update and list
+func rootURL(client *golangsdk.ServiceClient, instanceID string) string {
+	return client.ServiceURL(resourcePath, instanceID, topicPath)
+}
+
+// deleteURL will build the url of delete
+func deleteURL(client *golangsdk.ServiceClient, instanceID string) string {
+	return client.ServiceURL(resourcePath, instanceID, topicPath, "delete")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Package topics is only used by terraform-provider-flexibleengine with
DmsV1Client to manage flexibleengine_dms_kafka_topic resource.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
