### PR TITLE
feat(secgroup): add v3 sdk support for security groups and rules

### DIFF
--- a/openstack/networking/v3/security/groups/requests.go
+++ b/openstack/networking/v3/security/groups/requests.go
@@ -1,0 +1,159 @@
+package groups
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is a struct which will be used to create a new security group.
+type CreateOpts struct {
+	// Specifies the security group name. The value can contain 1 to 64 characters, including letters, digits,
+	// underscores (_), hyphens (-), and periods (.).
+	Name string `json:"name" required:"true"`
+	// Specifies the resource ID of the VPC to which the security group belongs.
+	// Note: This parameter has been discarded, it is not recommended to use it.
+	VpcId string `json:"vpc_id,omitempty"`
+	// Enterprise project ID. The default value is 0.
+	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+}
+
+// Create is a method to create a new security group.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*SecurityGroup, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "security_group")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(rootURL(c), b, &rst.Body, nil)
+	if err == nil {
+		var r SecurityGroup
+		rst.ExtractIntoStructPtr(&r, "security_group")
+		return &r, nil
+	}
+	return nil, err
+}
+
+// Get is a method to obtain the security group detail.
+func Get(c *golangsdk.ServiceClient, securityGroupId string) (*SecurityGroup, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, securityGroupId), &rst.Body, nil)
+	if err == nil {
+		var r SecurityGroup
+		rst.ExtractIntoStructPtr(&r, "security_group")
+		return &r, nil
+	}
+	return nil, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Specifies the number of records that will be returned on each page. The value is from 0 to intmax.
+	// limit can be used together with marker. For details, see the parameter description of marker.
+	Limit int `q:"limit"`
+	// Specifies a resource ID for pagination query, indicating that the query starts from the next record of the
+	// specified resource ID. This parameter can work together with the parameter limit.
+	//   If parameters marker and limit are not passed, all resource records will be returned.
+	//   If the parameter marker is not passed and the value of parameter limit is set to 10, the first 10 resource
+	//     records will be returned.
+	//   If the value of the parameter marker is set to the resource ID of the 10th record and the value of parameter
+	//     limit is set to 10, the 11th to 20th resource records will be returned.
+	//   If the value of the parameter marker is set to the resource ID of the 10th record and the parameter limit is
+	//     not passed, resource records starting from the 11th records (including 11th) will be returned.
+	Marker string `q:"marker"`
+	// Security group ID. You can use this field to filter security groups precisely, supporting multiple IDs.
+	ID string `q:"id"`
+	// Security group name. You can use this field to accurately filter security groups that meet the conditions, and
+	// support incoming multiple name filters.
+	Name string `q:"name"`
+	// Security group description. You can use this field to filter security groups precisely, and support multiple
+	// descriptions for filtering.
+	Description string `q:"description"`
+	// Enterprise project ID. Maximum length 36 bytes, UUID format with "-" hyphen, or string "0" (default).
+	// If the enterprise project sub-account needs to query all security groups under the enterprise project, please
+	// input 'all_granted_eps'.
+	EnterpriseProjectId string `q:"enterprise_project_id"`
+}
+
+// List is a method to obtain the list of the security groups.
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]SecurityGroup, error) {
+	url := rootURL(c)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := SecurityGroupPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractSecurityGroups(pages)
+}
+
+// UpdateOpts is a struct which will be used to update the existing security group using given parameters.
+type UpdateOpts struct {
+	// Specifies the security group name. The value can contain 1 to 64 characters, including letters, digits,
+	// underscores (_), hyphens (-), and periods (.).
+	Name string `json:"name,omitempty"`
+	// Specifies the description of the security group.
+	// The angle brackets (< and >) are not allowed for the description.
+	Description *string `json:"description,omitempty"`
+}
+
+// Update is a method to update an existing security group.
+func Update(c *golangsdk.ServiceClient, securityGroupId string, opts UpdateOpts) (*SecurityGroup, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "security_group")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Put(resourceURL(c, securityGroupId), b, &rst.Body, nil)
+	if err == nil {
+		var r SecurityGroup
+		rst.ExtractIntoStructPtr(&r, "security_group")
+		return &r, nil
+	}
+	return nil, err
+}
+
+// Delete is a method to delete an existing security group.
+func Delete(c *golangsdk.ServiceClient, securityGroupId string) *golangsdk.ErrResult {
+	var r golangsdk.ErrResult
+	_, r.Err = c.Delete(resourceURL(c, securityGroupId), nil)
+	return &r
+}
+
+// IDFromName is a convenience function that returns a securtiy group's ID, given its name.
+func IDFromName(client *golangsdk.ServiceClient, name string) (string, error) {
+	var count int
+	var id string
+	opt := ListOpts{
+		Name: name,
+	}
+	secgroupList, err := List(client, opt)
+	if err != nil {
+		return "", err
+	}
+	for _, sg := range secgroupList {
+		if sg.Name == name {
+			count++
+			id = sg.ID
+		}
+	}
+
+	switch count {
+	case 0:
+		return "", golangsdk.ErrResourceNotFound{Name: name, ResourceType: "Security Group"}
+	case 1:
+		return id, nil
+	default:
+		return "", golangsdk.ErrMultipleResourcesFound{Name: name, Count: count, ResourceType: "Security Group"}
+	}
+}

--- a/openstack/networking/v3/security/groups/results.go
+++ b/openstack/networking/v3/security/groups/results.go
@@ -1,0 +1,59 @@
+package groups
+
+import (
+	"github.com/chnsz/golangsdk/openstack/networking/v3/security/rules"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// SecurityGroup is a struct that represents the detail of the security group.
+type SecurityGroup struct {
+	// Specifies the security group name.
+	Name string `json:"name"`
+	// Provides supplementary information about the security group.
+	Description string `json:"description"`
+	// Specifies the security group ID, which uniquely identifies the security group.
+	ID string `json:"id"`
+	// Specifies the resource ID of the VPC to which the security group belongs.
+	// Note: This parameter has been discarded, it is not recommended to use it.
+	VpcId string `json:"vpc_id"`
+	// Enterprise project ID, the default value is 0.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// Specifies the default security group rules, which ensure that resources in the security group can communicate
+	// with one another.
+	SecurityGroupRules []rules.SecurityGroupRule `json:"security_group_rules"`
+	// ID of the project to which the security group rule belongs.
+	ProjectId string `json:"project_id"`
+	// Security group creation time, in UTC format: yyyy-MM-ddTHH:mm:ss.
+	CreatedAt string `json:"created_at"`
+	// Security group rule udpate time, in UTC format: yyyy-MM-ddTHH:mm:ss.
+	UpdatedAt string `json:"updated_at"`
+}
+
+type SecurityGroupPage struct {
+	pagination.MarkerPageBase
+}
+
+// LastMarker method returns the last security group ID in a security group page.
+func (p SecurityGroupPage) LastMarker() (string, error) {
+	secgroups, err := ExtractSecurityGroups(p)
+	if err != nil {
+		return "", err
+	}
+	if len(secgroups) == 0 {
+		return "", nil
+	}
+	return secgroups[len(secgroups)-1].ID, nil
+}
+
+// IsEmpty method checks whether the current security group page is empty.
+func (p SecurityGroupPage) IsEmpty() (bool, error) {
+	secgroups, err := ExtractSecurityGroups(p)
+	return len(secgroups) == 0, err
+}
+
+// ExtractSecurityGroups is a method to extract the list of security group details.
+func ExtractSecurityGroups(r pagination.Page) ([]SecurityGroup, error) {
+	var s []SecurityGroup
+	r.(SecurityGroupPage).Result.ExtractIntoSlicePtr(&s, "security_groups")
+	return s, nil
+}

--- a/openstack/networking/v3/security/groups/urls.go
+++ b/openstack/networking/v3/security/groups/urls.go
@@ -1,0 +1,11 @@
+package groups
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("vpc/security-groups")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, secgroupId string) string {
+	return c.ServiceURL("vpc/security-groups", secgroupId)
+}

--- a/openstack/networking/v3/security/rules/requests.go
+++ b/openstack/networking/v3/security/rules/requests.go
@@ -1,0 +1,133 @@
+package rules
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is a struct which will be used to create a new security group rule.
+type CreateOpts struct {
+	// Specifies the security group ID.
+	SecurityGroupId string `json:"security_group_id" required:"true"`
+	// Provides supplementary information about the security group rule.
+	// The value can contain no more than 255 characters, including letters and digits.
+	Description string `json:"description,omitempty"`
+	// Specifies the direction of access control.
+	// Possible values are as follows:
+	//   egress
+	//   ingress
+	Direction string `json:"direction" required:"true"`
+	// Specifies the IP protocol version. The value can be IPv4 or IPv6. The default value is IPv4.
+	Ethertype string `json:"ethertype,omitempty"`
+	// Specifies the protocol type. The value can be icmp, tcp, or udp.
+	// If the parameter is left blank, all protocols are supported.
+	Protocol string `json:"protocol,omitempty"`
+	// Specifies the port value range, which supports single port (80), continuous port (1-30) and discontinuous
+	// port (22, 3389, 80). The range of port values is range form 1 to 65,535.
+	MultiPort string `json:"multiport,omitempty"`
+	// Specifies the remote IP address.
+	// If the access control direction is set to egress, the parameter specifies the source IP address.
+	// If the access control direction is set to ingress, the parameter specifies the destination IP address.
+	// The value can be in the CIDR format or IP addresses.
+	// The parameter is exclusive with parameter remote_group_id.
+	RemoteIpPrefix string `json:"remote_ip_prefix,omitempty"`
+	// Specifies the ID of the peer security group.
+	// The value is exclusive with parameter remote_ip_prefix.
+	RemoteGroupId string `json:"remote_group_id,omitempty"`
+	// Specifies the ID of the peer security group.
+	// The value is exclusive with parameter remote_ip_prefix.
+	RemoteAddressGroupId string `json:"remote_address_group_id,omitempty"`
+	// Specifies the ID of the peer security group.
+	// The value is exclusive with parameter remote_ip_prefix.
+	Action string `json:"action,omitempty"`
+	// Specifies the ID of the peer security group.
+	// The value is exclusive with parameter remote_ip_prefix.
+	Priority string `json:"priority,omitempty"`
+}
+
+// Create is a method to create a new security group rule.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*SecurityGroupRule, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "security_group_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(rootURL(c), b, &rst.Body, nil)
+	if err == nil {
+		var r SecurityGroupRule
+		rst.ExtractIntoStructPtr(&r, "security_group_rule")
+		return &r, nil
+	}
+	return nil, err
+}
+
+// Get is a method to obtain the security group rule detail.
+func Get(c *golangsdk.ServiceClient, ruleId string) (*SecurityGroupRule, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, ruleId), &rst.Body, nil)
+	if err == nil {
+		var r SecurityGroupRule
+		rst.ExtractIntoStructPtr(&r, "security_group_rule")
+		return &r, nil
+	}
+	return nil, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Specifies a resource ID for pagination query, indicating that the query starts from the next record of the
+	// specified resource ID. This parameter can work together with the parameter limit.
+	//   1. If parameters marker and limit are not passed, all resource records will be returned.
+	//   2. If the parameter marker is not passed and the value of parameter limit is set to 10, the first 10 resource
+	//     records will be returned.
+	//   3. If the value of the parameter marker is set to the resource ID of the 10th record and the value of parameter
+	//     limit is set to 10, the 11th to 20th resource records will be returned.
+	//   4. If the value of the parameter marker is set to the resource ID of the 10th record and the parameter limit is
+	//     not passed, resource records starting from the 11th records (including 11th) will be returned.
+	Marker string `q:"marker"`
+	// Specifies the number of records that will be returned on each page. The value is from 0 to intmax.
+	// limit can be used together with marker. For details, see the parameter description of marker.
+	Limit int `q:"limit"`
+	// Specifies the security group ID.
+	SecurityGroupId string `q:"security_group_id"`
+	// Security group rule protocol, support multiple filtering
+	Protocol string `q:"protocol"`
+	// Security group description added. You can use this field to filter security groups precisely, and support
+	// multiple descriptions for filtering.
+	Description string `q:"description"`
+	// Remote security group ID, support multiple ID filtering.
+	RemoteGroupId string `q:"remote_group_id"`
+	// Security group rule direction.
+	Direction string `q:"direction"`
+	// Security group rules take effect policy.
+	Action string `q:"action"`
+}
+
+// List is a method to obtain the list of the security group rules.
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]SecurityGroupRule, error) {
+	url := rootURL(c)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := SecurityGroupRulePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractSecurityGroupRules(pages)
+}
+
+// Delete is a method to delete an existing security group rule.
+func Delete(c *golangsdk.ServiceClient, securityGroupRuleId string) *golangsdk.ErrResult {
+	var r golangsdk.ErrResult
+	_, r.Err = c.Delete(resourceURL(c, securityGroupRuleId), nil)
+	return &r
+}

--- a/openstack/networking/v3/security/rules/results.go
+++ b/openstack/networking/v3/security/rules/results.go
@@ -1,0 +1,83 @@
+package rules
+
+import "github.com/chnsz/golangsdk/pagination"
+
+// SecurityGroupRule is a struct that represents the detail of the security group rule.
+type SecurityGroupRule struct {
+	// Specifies the security group rule ID, which uniquely identifies the security group rule.
+	ID string `json:"id"`
+	// Provides supplementary information about the security group rule.
+	// The value can contain no more than 255 characters, including letters and digits.
+	Description string `json:"description"`
+	// Specifies the security group ID, which uniquely identifies the security group.
+	SecurityGroupId string `json:"security_group_id"`
+	// Specifies the direction of access control.
+	// Possible values are as follows:
+	//   egress
+	//   ingress
+	Direction string `json:"direction"`
+	// Specifies the protocol type. The value can be icmp, tcp, udp, icmpv6 or protocol number.
+	// If the parameter is left blank, all protocols are supported.
+	// When the protocol is icmpv6, the network type should be IPv6.
+	// when the protocol is icmp, the network type should be IPv4.
+	Protocol string `json:"protocol"`
+	// Specifies the IP protocol version. The value can be IPv4 or IPv6.
+	Ethertype string `json:"ethertype"`
+	// Port value range.
+	// Value range: support and single port (80), contiguous port (1-30) and discontinuous port (22, 3389, 80).
+	MultiPort string `json:"multiport"`
+	// Security group rules take effect policy.
+	//   allow
+	//   deny
+	// Default is deny.
+	Action string `json:"action"`
+	// Priority
+	// Value range: 1~100, 1 represents the highest priority.
+	Priority string `json:"priority"`
+	// Specifies the remote IP address.
+	// If the access control direction is set to egress, the parameter specifies the source IP address.
+	// If the access control direction is set to ingress, the parameter specifies the destination IP address.
+	// The value can be in the CIDR format or IP addresses.
+	// The parameter is exclusive with parameter remote_group_id.
+	RemoteIpPrefix string `json:"remote_ip_prefix"`
+	// Specifies the ID of the peer security group.
+	// The value is exclusive with parameter remote_ip_prefix.
+	RemoteGroupId string `json:"remote_group_id"`
+	// Remote address group ID. Mutually exclusive with remote_ip_prefix, remote_group_id parameters.
+	RemoteAddressGroupId string `json:"remote_address_group_id"`
+	// Security group rule creation time, in UTC format: yyyy-MM-ddTHH:mm:ss.
+	CreateAt string `json:"created_at"`
+	// Security group rule udpate time, in UTC format: yyyy-MM-ddTHH:mm:ss.
+	UpdateAt string `json:"updated_at"`
+	// ID of the project to which the security group rule belongs.
+	ProjectId string `json:"project_id"`
+}
+
+type SecurityGroupRulePage struct {
+	pagination.MarkerPageBase
+}
+
+// LastMarker method returns the last security group rule ID in a SecurityGroupRulePage.
+func (p SecurityGroupRulePage) LastMarker() (string, error) {
+	secgroups, err := ExtractSecurityGroupRules(p)
+	if err != nil {
+		return "", err
+	}
+	if len(secgroups) == 0 {
+		return "", nil
+	}
+	return secgroups[len(secgroups)-1].ID, nil
+}
+
+// IsEmpty method checks whether the current SecurityGroupRulePage is empty.
+func (p SecurityGroupRulePage) IsEmpty() (bool, error) {
+	secgroups, err := ExtractSecurityGroupRules(p)
+	return len(secgroups) == 0, err
+}
+
+// ExtractSecurityGroupRules is a method to extract the list of security group rule details.
+func ExtractSecurityGroupRules(r pagination.Page) ([]SecurityGroupRule, error) {
+	var s []SecurityGroupRule
+	r.(SecurityGroupRulePage).Result.ExtractIntoSlicePtr(&s, "security_group_rules")
+	return s, nil
+}

--- a/openstack/networking/v3/security/rules/urls.go
+++ b/openstack/networking/v3/security/rules/urls.go
@@ -1,0 +1,11 @@
+package rules
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("vpc/security-group-rules")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, ruleId string) string {
+	return c.ServiceURL("vpc/security-group-rules", ruleId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The OpenStack Nova API does not support EPS permission, need to use the v3 sdk to fix it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. support v3 sdks of security groups and rules.
```
