### PR TITLE
fix(lb/monitors): fix arg 'Type' in UpdateOpts to omitempty

### DIFF
--- a/openstack/elb/v2/listeners/results.go
+++ b/openstack/elb/v2/listeners/results.go
@@ -2,8 +2,8 @@ package listeners
 
 import (
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/l7policies"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/pools"
+	"github.com/chnsz/golangsdk/openstack/elb/v2/l7policies"
+	"github.com/chnsz/golangsdk/openstack/elb/v2/pools"
 	"github.com/chnsz/golangsdk/pagination"
 )
 

--- a/openstack/elb/v2/loadbalancers/results.go
+++ b/openstack/elb/v2/loadbalancers/results.go
@@ -2,8 +2,8 @@ package loadbalancers
 
 import (
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/pools"
+	"github.com/chnsz/golangsdk/openstack/elb/v2/listeners"
+	"github.com/chnsz/golangsdk/openstack/elb/v2/pools"
 	"github.com/chnsz/golangsdk/pagination"
 )
 

--- a/openstack/elb/v2/loadbalancers/testing/fixtures.go
+++ b/openstack/elb/v2/loadbalancers/testing/fixtures.go
@@ -8,10 +8,10 @@ import (
 	th "github.com/chnsz/golangsdk/testhelper"
 	"github.com/chnsz/golangsdk/testhelper/client"
 
+	"github.com/chnsz/golangsdk/openstack/elb/v2/listeners"
 	"github.com/chnsz/golangsdk/openstack/elb/v2/loadbalancers"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/listeners"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/monitors"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/pools"
+	"github.com/chnsz/golangsdk/openstack/elb/v2/monitors"
+	"github.com/chnsz/golangsdk/openstack/elb/v2/pools"
 )
 
 // LoadbalancersListBody contains the canned body of a loadbalancer list response.

--- a/openstack/elb/v2/monitors/requests.go
+++ b/openstack/elb/v2/monitors/requests.go
@@ -214,7 +214,7 @@ type UpdateOpts struct {
 
 	// Specifies the health check protocol.
 	// The value can be TCP, UDP_CONNECT, or HTTP.
-	Type string `json:"type" required:"true"`
+	Type string `json:"type,omitempty"`
 
 	// URI path that will be accessed if Monitor type is HTTP or HTTPS.
 	// Required for HTTP(S) types.

--- a/openstack/elb/v2/pools/results.go
+++ b/openstack/elb/v2/pools/results.go
@@ -2,7 +2,7 @@ package pools
 
 import (
 	"github.com/chnsz/golangsdk"
-	"github.com/chnsz/golangsdk/openstack/networking/v2/extensions/lbaas_v2/monitors"
+	"github.com/chnsz/golangsdk/openstack/elb/v2/monitors"
 	"github.com/chnsz/golangsdk/pagination"
 )
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

A new argument `Type` is added to UpdateOpts in #100 . But it is mistakenly set to required.
This need to be fixed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
fix arg 'type' in UpdateOpts to omitempty
```

Testing result:
```
go test ./openstack/elb/v2/loadbalancers/testing -v -run Test
=== RUN   TestListLoadbalancers
--- PASS: TestListLoadbalancers (0.01s)
=== RUN   TestListAllLoadbalancers
--- PASS: TestListAllLoadbalancers (0.00s)
=== RUN   TestCreateLoadbalancer
--- PASS: TestCreateLoadbalancer (0.01s)
=== RUN   TestRequiredCreateOpts
--- PASS: TestRequiredCreateOpts (0.00s)
=== RUN   TestGetLoadbalancer
--- PASS: TestGetLoadbalancer (0.01s)
=== RUN   TestGetLoadbalancerStatusesTree
--- PASS: TestGetLoadbalancerStatusesTree (0.01s)
=== RUN   TestDeleteLoadbalancer
--- PASS: TestDeleteLoadbalancer (0.00s)
=== RUN   TestUpdateLoadbalancer
--- PASS: TestUpdateLoadbalancer (0.00s)
=== RUN   TestCascadingDeleteLoadbalancer
--- PASS: TestCascadingDeleteLoadbalancer (0.00s)
PASS
ok      github.com/chnsz/golangsdk/openstack/elb/v2/loadbalancers/testing       0.096s
```