### PR TITLE
feat(cloudtable/cluster): add new cluster sdk support

### DIFF
--- a/openstack/cloudtable/v2/clusters/requests.go
+++ b/openstack/cloudtable/v2/clusters/requests.go
@@ -1,0 +1,108 @@
+package clusters
+
+import "github.com/chnsz/golangsdk"
+
+// CreateOpts is a struct which will be used to create a new cloudtable cluster.
+type CreateOpts struct {
+	// Create cluster database parameters.
+	Datastore Datastore `json:"datastore" required:"true"`
+	// Cluster name
+	Name string `json:"name" required:"true"`
+	// The instance object of the cluster.
+	Instance Instance `json:"instance" required:"true"`
+	// Storage type, the valid values are:
+	//   ULTRAHIGH
+	//   COMMON
+	StorageType string `json:"storage_type" required:"true"`
+	// The VPC where the cluster is located.
+	VpcId string `json:"vpc_id" required:"true"`
+	// Whether the IAM auth is enabled.
+	IAMAuthEnabled bool `json:"auth_mode,omitempty"`
+	// Whether the Lemon is enabled.
+	LemonEnabled bool `json:"enable_lemon,omitempty"`
+	// Whether the OpenTSDB is enabled.
+	OpenTSDBEnabled bool `json:"enable_openTSDB,omitempty"`
+	// The size of the stored value.
+	StorageSize int `json:"storage_size,omitempty"`
+}
+
+// Datastore is an object specifying the cluster storage.
+type Datastore struct {
+	// Cluster database type.
+	Type string `json:"type" required:"true"`
+	// Controller version number, default to '1.0.6'.
+	Version string `json:"version" required:"true"`
+}
+
+// Instance is an object specifying the information of the nodes number, az and network.
+type Instance struct {
+	// The ID of the availability zone where the cluster is located.
+	AvailabilityZone string `json:"availability_zone" required:"true"`
+	// The number of computing unit nodes in the CloudTable cluster must be at least 2.
+	CUNum int `json:"cu_num" required:"true"`
+	// Information about the network where the cluster is located.
+	Networks []Network `json:"nics" required:"true"`
+	// The number of Lemon nodes in the CloudTable cluster.
+	LemonNum int `json:"lemon_num,omitempty"`
+	// The number of TSD nodes in the CloudTable cluster must be at least 2.
+	TSDNum int `json:"tsd_num,omitempty"`
+}
+
+// Network is an object specifying the cluster network.
+type Network struct {
+	// The ID of the network where the CloudTable cluster is located.
+	SubnetId string `json:"net_id" required:"true"`
+	// The ID of the security group to which the CloudTable belongs.
+	SecurityGroupId string `json:"security_group_id" required:"true"`
+}
+
+// Create is a method to create a new cluster.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*RequestResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "cluster")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(rootURL(c), b, &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"X-Language":   "en-us",
+		},
+	})
+	if err == nil {
+		var r RequestResp
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// Get is a method to obtain the detail of the cluster.
+func Get(c *golangsdk.ServiceClient, clusterId string) (*Cluster, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, clusterId), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"X-Language":   "en-us",
+		},
+	})
+	if err == nil {
+		var r Cluster
+		rst.ExtractInto(&r)
+		return &r, nil
+	}
+	return nil, err
+}
+
+// Delete is a method to remove an existing cluster by ID.
+func Delete(c *golangsdk.ServiceClient, clusterId string) *golangsdk.ErrResult {
+	var r golangsdk.ErrResult
+	_, r.Err = c.Delete(resourceURL(c, clusterId), &golangsdk.RequestOpts{
+		MoreHeaders: map[string]string{
+			"Content-Type": "application/json",
+			"X-Language":   "en-us",
+		},
+	})
+	return &r
+}

--- a/openstack/cloudtable/v2/clusters/results.go
+++ b/openstack/cloudtable/v2/clusters/results.go
@@ -1,0 +1,73 @@
+package clusters
+
+type RequestResp struct {
+	// Cluster ID.
+	ClusterId string `json:"cluster_id"`
+}
+
+type Cluster struct {
+	// Cluster datastore.
+	Datastore Datastore `json:"datastore"`
+	// The current status list of the cluster:
+	//   CREATING
+	//   GROWING
+	Actions []string `json:"actions"`
+	// Whether the openTSDB is enabled.
+	OpenTSDBEnabled bool `json:"enable_openTSDB"`
+	// Whether the Lemon is enabled.
+	LemonEnabled bool `json:"enable_lemon"`
+	// The name of the CloudTable cluster.
+	Name string `json:"cluster_name"`
+	// The number of RegionServers.
+	CUNum string `json:"cu_num"`
+	// The number of TSD nodes.
+	TSDNum string `json:"tsd_num"`
+	// The number of Lemon nodes.
+	LemonNum string `json:"lemon_num"`
+	// Cluster bottom storage type:
+	//   OBS
+	//   HDFS
+	StorageType string `json:"storage_type"`
+	// Cluster storage quota.
+	StorageQuota string `json:"storage_quota"`
+	// Storage space currently in use.
+	StorageUsed string `json:"used_storage_size"`
+	// Whether the IAM auth is enabled.
+	IAMAuthEnabled bool `json:"auth_mode"`
+	// The time when the disk was updated.
+	UpdatedAt string `json:"updated"`
+	// The time when the disk was created.
+	CreateAt string `json:"created"`
+	// Cluster ID.
+	ID string `json:"cluster_id"`
+	// Cluster status.
+	//   100 Creating
+	//   200 Running
+	//   300 Abnormal
+	//   303 Creation failed
+	//   400 Deleted
+	//   800 Frezon
+	Status string `json:"status"`
+	// Intranet OpenTSDB connection access address.
+	OpenTSDBLink string `json:"openTSDB_link"`
+	// OpenTSDB public network endpoint address.
+	TSDPublicEndpoint string `json:"tsd_public_endpoint"`
+	// Intranet Lemon connection access address.
+	LemonLink string `json:"lemon_link"`
+	// Intranet ZooKeeper connection access address.
+	ZookeeperLink string `json:"zookeeper_link"`
+	// HBase connection access address on the public network.
+	HbasePublicEndpoint string `json:"hbase_public_endpoint"`
+	// Whether the cluster is frozen.
+	//   false
+	//   true
+	IsFrozen string `json:"is_frozen"`
+	// The VPC where the cluster is located.
+	VpcId string `json:"vpc_id"`
+	// The ID of the network where the CloudTable cluster is located.
+	SubnetId string `json:"subnet_id"`
+	// The ID of the security group to which the CloudTable belongs.
+	SecurityGroupId string `json:"security_group_id"`
+	// The ID of the availability zone where the cluster is located.
+	AvailabilityZone string `json:"availability_zone"`
+}

--- a/openstack/cloudtable/v2/clusters/urls.go
+++ b/openstack/cloudtable/v2/clusters/urls.go
@@ -1,0 +1,13 @@
+package clusters
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "clusters"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, clusterId string) string {
+	return c.ServiceURL(rootPath, clusterId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The v2 API of the CloudTable cluster has been released. To support the development of `huaweicloud_cloudtable_cluster`, the new SDK needs to be supported.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. add new cluster sdk support of the CloudTable cluster.
```
