### PR TITLE
fix(volume/list): use marker pages instead of linked pages

### DIFF
--- a/openstack/evs/v2/cloudvolumes/requests.go
+++ b/openstack/evs/v2/cloudvolumes/requests.go
@@ -285,6 +285,8 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 	}
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return VolumePage{pagination.LinkedPageBase{PageResult: r}}
+		p := VolumePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
 	})
 }

--- a/openstack/evs/v2/cloudvolumes/results.go
+++ b/openstack/evs/v2/cloudvolumes/results.go
@@ -129,26 +129,25 @@ type Volume struct {
 
 // VolumePage is a pagination.pager that is returned from a call to the List function.
 type VolumePage struct {
-	pagination.LinkedPageBase
+	pagination.MarkerPageBase
+}
+
+// LastMarker returns the last route table ID in a ListResult
+func (b VolumePage) LastMarker() (string, error) {
+	volumes, err := ExtractVolumes(b)
+	if err != nil {
+		return "", err
+	}
+	if len(volumes) == 0 {
+		return "", nil
+	}
+	return volumes[len(volumes)-1].ID, nil
 }
 
 // IsEmpty returns true if a ListResult contains no Volumes.
 func (r VolumePage) IsEmpty() (bool, error) {
 	volumes, err := ExtractVolumes(r)
 	return len(volumes) == 0, err
-}
-
-// NextPageURL uses the response's embedded link reference to navigate to the
-// next page of results.
-func (r VolumePage) NextPageURL() (string, error) {
-	var s struct {
-		Links []golangsdk.Link `json:"volumes_links"`
-	}
-	err := r.ExtractInto(&s)
-	if err != nil {
-		return "", err
-	}
-	return golangsdk.ExtractNextURL(s.Links)
 }
 
 // ExtractVolumes extracts and returns Volumes. It is used while iterating over a cloudvolumes.List call.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
According to the recently updated interface design, marker pages should be used as the pagination page for list query.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. Use marker pages instead of linked pages.
```
