### PR TITLE
fix(elb): change type of Description to pointer in UpdateOpts

### DIFF
--- a/openstack/elb/v2/listeners/requests.go
+++ b/openstack/elb/v2/listeners/requests.go
@@ -173,7 +173,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Human-readable description for the Listener.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The maximum number of connections allowed for the Listener.
 	ConnLimit *int `json:"connection_limit,omitempty"`

--- a/openstack/elb/v2/loadbalancers/requests.go
+++ b/openstack/elb/v2/loadbalancers/requests.go
@@ -148,7 +148,7 @@ type UpdateOpts struct {
 	Name string `json:"name,omitempty"`
 
 	// Human-readable description for the Loadbalancer.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// The administrative state of the Loadbalancer. A valid value is true (UP)
 	// or false (DOWN).

--- a/openstack/elb/v3/listeners/requests.go
+++ b/openstack/elb/v3/listeners/requests.go
@@ -143,6 +143,12 @@ type IpGroupUpdate struct {
 
 // UpdateOpts represents options for updating a Listener.
 type UpdateOpts struct {
+	// Human-readable name for the Listener. Does not have to be unique.
+	Name string `json:"name,omitempty"`
+
+	// Human-readable description for the Listener.
+	Description *string `json:"description,omitempty"`
+
 	// The administrative state of the Listener. A valid value is true (UP)
 	// or false (DOWN).
 	AdminStateUp *bool `json:"admin_state_up,omitempty"`
@@ -156,14 +162,8 @@ type UpdateOpts struct {
 	// A reference to a container of TLS secrets.
 	DefaultTlsContainerRef *string `json:"default_tls_container_ref,omitempty"`
 
-	// Human-readable description for the Listener.
-	Description string `json:"description,omitempty"`
-
 	// whether to use HTTP2.
 	Http2Enable *bool `json:"http2_enable,omitempty"`
-
-	// Human-readable name for the Listener. Does not have to be unique.
-	Name string `json:"name,omitempty"`
 
 	// A list of references to TLS secrets.
 	SniContainerRefs *[]string `json:"sni_container_refs,omitempty"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
change type of Description to pointer in UpdateOpts, then we can update this field to null.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
