### PR TITLE
feat(cci/network): add list method to obtain namespace networks

### DIFF
--- a/openstack/cci/v1/networks/requests.go
+++ b/openstack/cci/v1/networks/requests.go
@@ -76,6 +76,18 @@ func Get(c *golangsdk.ServiceClient, ns, id string) (r GetResult) {
 	return
 }
 
+// List is a method to obtain namespace networks.
+func List(c *golangsdk.ServiceClient, ns string) ([]Network, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(rootURL(c, ns), &rst.Body, nil)
+	if err == nil {
+		var r []Network
+		rst.ExtractIntoSlicePtr(&r, "items")
+		return r, nil
+	}
+	return nil, err
+}
+
 // Delete will permanently delete a particular network based on its unique ID.
 func Delete(c *golangsdk.ServiceClient, ns, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(resourceURL(c, ns, id), &golangsdk.RequestOpts{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Since the query interfaces of the CCI namespace does not return relevant information about the network, it is necessary to provide a List method to query the network information of the current namespace.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. add list method to obtain namespace networks.
```
