### PR TITLE
fix(csbs): do not unmarshal average_speed item

### DIFF
--- a/openstack/csbs/v1/backup/results.go
+++ b/openstack/csbs/v1/backup/results.go
@@ -106,7 +106,7 @@ type Backup struct {
 
 type ExtendInfo struct {
 	AutoTrigger          bool           `json:"auto_trigger"`
-	AverageSpeed         int            `json:"average_speed"`
+	AverageSpeed         int            `json:"-"`
 	CopyFrom             string         `json:"copy_from"`
 	CopyStatus           string         `json:"copy_status"`
 	FailCode             FailCode       `json:"fail_code"`
@@ -145,7 +145,7 @@ type FailCode struct {
 }
 
 type VolumeBackup struct {
-	AverageSpeed     int    `json:"average_speed"`
+	AverageSpeed     int    `json:"-"`
 	Bootable         bool   `json:"bootable"`
 	Id               string `json:"id"`
 	ImageType        string `json:"image_type"`

--- a/openstack/csbs/v1/backup/testing/requests_test.go
+++ b/openstack/csbs/v1/backup/testing/requests_test.go
@@ -155,7 +155,6 @@ func TestList(t *testing.T) {
 				ResourceAz:           "eu-de-02",
 				ImageType:            "backup",
 				FinishedAt:           FinishedAt,
-				AverageSpeed:         19,
 				CopyStatus:           "na",
 				Incremental:          false,
 				TaskId:               "1afcab08-9f97-11e8-9526-286ed488ca8c",


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

when unmarshal  the API response of GET method, an error is arising:
```
json: cannot unmarshal number 28.1 into Go struct field .checkpoint_item of type int
```

the API Response Body is as follows:
```
{
  "checkpoint_item": {
    "extend_info": {
      "average_speed": 28.1,
      "volume_backups": [
        {
         "average_speed": 0,
        }
      ]
    },
  }
}
```

actually, we doesn't use the **average_speed** item, so we can not unmarshal it as the response maybe changed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
