### PR TITLE
chore: remove some non-standard usages in urls.go

### DIFF
--- a/openstack/apigw/dedicated/v2/apis/urls.go
+++ b/openstack/apigw/dedicated/v2/apis/urls.go
@@ -1,37 +1,31 @@
 package apis
 
 import (
-	"fmt"
-
 	"github.com/chnsz/golangsdk"
 )
 
 const rootPath = "instances"
 
-func buildRootPath(instanceId string) string {
-	return fmt.Sprintf("instances/%s/apis", instanceId)
-}
-
 func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
-	return c.ServiceURL(buildRootPath(instanceId))
+	return c.ServiceURL(rootPath, instanceId, "apis")
 }
 
 func resourceURL(c *golangsdk.ServiceClient, instanceId, apiId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), apiId)
+	return c.ServiceURL(rootPath, instanceId, "apis", apiId)
 }
 
 func releaseURL(c *golangsdk.ServiceClient, instanceId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), "action")
+	return c.ServiceURL(rootPath, instanceId, "apis", "action")
 }
 
 func batchPublishURL(c *golangsdk.ServiceClient, instanceId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), "publish")
+	return c.ServiceURL(rootPath, instanceId, "apis", "publish")
 }
 
 func publishVersionURL(c *golangsdk.ServiceClient, instanceId, apiId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), "publish", apiId)
+	return c.ServiceURL(rootPath, instanceId, "apis", "publish", apiId)
 }
 
 func showHistoryDetailURL(c *golangsdk.ServiceClient, instanceId, versionId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), "version", versionId)
+	return c.ServiceURL(rootPath, instanceId, "apis", "version", versionId)
 }

--- a/openstack/apigw/dedicated/v2/channels/urls.go
+++ b/openstack/apigw/dedicated/v2/channels/urls.go
@@ -1,27 +1,21 @@
 package channels
 
 import (
-	"fmt"
-
 	"github.com/chnsz/golangsdk"
 )
 
-func buildRootPath(instanceId string) string {
-	return fmt.Sprintf("instances/%s/vpc-channels", instanceId)
-}
-
 func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
-	return c.ServiceURL(buildRootPath(instanceId))
+	return c.ServiceURL("instances", instanceId, "vpc-channels")
 }
 
 func resourceURL(c *golangsdk.ServiceClient, instanceId, chanId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), chanId)
+	return c.ServiceURL("instances", instanceId, "vpc-channels", chanId)
 }
 
 func membersURL(c *golangsdk.ServiceClient, instanceId, chanId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), chanId, "members")
+	return c.ServiceURL("instances", instanceId, "vpc-channels", chanId, "members")
 }
 
 func memberURL(c *golangsdk.ServiceClient, instanceId, chanId, memberId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), chanId, "members", memberId)
+	return c.ServiceURL("instances", instanceId, "vpc-channels", chanId, "members", memberId)
 }

--- a/openstack/apigw/dedicated/v2/responses/requests.go
+++ b/openstack/apigw/dedicated/v2/responses/requests.go
@@ -68,7 +68,7 @@ func Create(client *golangsdk.ServiceClient, opts ResponseOptsBuilder) (r Create
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Post(rootURL(client, buildResponsesPath(opts.GetInstanceId(), opts.GetGroupId())),
+	_, r.Err = client.Post(rootURL(client, opts.GetInstanceId(), opts.GetGroupId()),
 		reqBody, &r.Body, nil)
 	return
 }
@@ -80,7 +80,7 @@ func Update(client *golangsdk.ServiceClient, respId string, opts ResponseOptsBui
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Put(resourceURL(client, buildResponsesPath(opts.GetInstanceId(), opts.GetGroupId()), respId),
+	_, r.Err = client.Put(resourceURL(client, opts.GetInstanceId(), opts.GetGroupId(), respId),
 		reqBody, &r.Body, &golangsdk.RequestOpts{
 			OkCodes: []int{200},
 		})
@@ -89,7 +89,7 @@ func Update(client *golangsdk.ServiceClient, respId string, opts ResponseOptsBui
 
 // Get is a method to obtain the specified custom response according to the instanceId, appId and respId.
 func Get(client *golangsdk.ServiceClient, instanceId, groupId, respId string) (r GetResult) {
-	_, r.Err = client.Get(resourceURL(client, buildResponsesPath(instanceId, groupId), respId), &r.Body, nil)
+	_, r.Err = client.Get(resourceURL(client, instanceId, groupId, respId), &r.Body, nil)
 	return
 }
 
@@ -130,7 +130,7 @@ func (opts ListOpts) ToListQuery() (string, error) {
 
 // List is a method to obtain an array of one or more custom reponses according to the query parameters.
 func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
-	url := rootURL(client, buildResponsesPath(opts.GetInstanceId(), opts.GetGroupId()))
+	url := rootURL(client, opts.GetInstanceId(), opts.GetGroupId())
 	if opts != nil {
 		query, err := opts.ToListQuery()
 		if err != nil {
@@ -146,7 +146,7 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 
 // Delete is a method to delete the existing custom response.
 func Delete(client *golangsdk.ServiceClient, instanceId, groupId, respId string) (r DeleteResult) {
-	_, r.Err = client.Delete(resourceURL(client, buildResponsesPath(instanceId, groupId), respId), nil)
+	_, r.Err = client.Delete(resourceURL(client, instanceId, groupId, respId), nil)
 	return
 }
 
@@ -177,8 +177,8 @@ func (opts SpecRespOpts) GetResponseId() string {
 
 // GetSpecResp is a method to get the specifies custom response configuration from an group.
 func GetSpecResp(client *golangsdk.ServiceClient, respType string, opts SpecRespOptsBuilder) (r GetSpecRespResult) {
-	_, r.Err = client.Get(specResponsesURL(client, buildResponsesPath(opts.GetInstanceId(), opts.GetGroupId()),
-		opts.GetResponseId(), respType), &r.Body, nil)
+	url := specResponsesURL(client, opts.GetInstanceId(), opts.GetGroupId(), opts.GetResponseId(), respType)
+	_, r.Err = client.Get(url, &r.Body, nil)
 	return
 }
 
@@ -198,8 +198,8 @@ func UpdateSpecResp(client *golangsdk.ServiceClient, respType string, specOpts S
 		r.Err = err
 		return
 	}
-	_, r.Err = client.Put(specResponsesURL(client, buildResponsesPath(specOpts.GetInstanceId(), specOpts.GetGroupId()),
-		specOpts.GetResponseId(), respType), reqBody, &r.Body, &golangsdk.RequestOpts{
+	url := specResponsesURL(client, specOpts.GetInstanceId(), specOpts.GetGroupId(), specOpts.GetResponseId(), respType)
+	_, r.Err = client.Put(url, reqBody, &r.Body, &golangsdk.RequestOpts{
 		OkCodes: []int{200},
 	})
 	return
@@ -207,7 +207,7 @@ func UpdateSpecResp(client *golangsdk.ServiceClient, respType string, specOpts S
 
 // DeleteSpecResp is a method to delete an existing custom response configuration from an group.
 func DeleteSpecResp(client *golangsdk.ServiceClient, respType string, specOpts SpecRespOptsBuilder) (r DeleteResult) {
-	_, r.Err = client.Delete(specResponsesURL(client, buildResponsesPath(specOpts.GetInstanceId(),
-		specOpts.GetGroupId()), specOpts.GetResponseId(), respType), nil)
+	url := specResponsesURL(client, specOpts.GetInstanceId(), specOpts.GetGroupId(), specOpts.GetResponseId(), respType)
+	_, r.Err = client.Delete(url, nil)
 	return
 }

--- a/openstack/apigw/dedicated/v2/responses/urls.go
+++ b/openstack/apigw/dedicated/v2/responses/urls.go
@@ -1,23 +1,17 @@
 package responses
 
 import (
-	"fmt"
-
 	"github.com/chnsz/golangsdk"
 )
 
-func buildResponsesPath(instanceId, groupId string) string {
-	return fmt.Sprintf("instances/%s/api-groups/%s/gateway-responses", instanceId, groupId)
+func rootURL(c *golangsdk.ServiceClient, instanceId, groupId string) string {
+	return c.ServiceURL("instances", instanceId, "api-groups", groupId, "gateway-responses")
 }
 
-func rootURL(c *golangsdk.ServiceClient, path string) string {
-	return c.ServiceURL(path)
+func resourceURL(c *golangsdk.ServiceClient, instanceId, groupId, respId string) string {
+	return c.ServiceURL("instances", instanceId, "api-groups", groupId, "gateway-responses", respId)
 }
 
-func resourceURL(c *golangsdk.ServiceClient, path, respId string) string {
-	return c.ServiceURL(path, respId)
-}
-
-func specResponsesURL(c *golangsdk.ServiceClient, path, respId, respType string) string {
-	return c.ServiceURL(path, respId, respType)
+func specResponsesURL(c *golangsdk.ServiceClient, instanceId, groupId, respId, respType string) string {
+	return c.ServiceURL("instances", instanceId, "api-groups", groupId, "gateway-responses", respId, respType)
 }

--- a/openstack/apigw/dedicated/v2/throttles/urls.go
+++ b/openstack/apigw/dedicated/v2/throttles/urls.go
@@ -1,27 +1,21 @@
 package throttles
 
 import (
-	"fmt"
-
 	"github.com/chnsz/golangsdk"
 )
 
-func buildRootPath(instanceId string) string {
-	return fmt.Sprintf("instances/%s/throttles", instanceId)
-}
-
 func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
-	return c.ServiceURL(buildRootPath(instanceId))
+	return c.ServiceURL("instances", instanceId, "throttles")
 }
 
 func resourceURL(c *golangsdk.ServiceClient, instanceId, policyId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), policyId)
+	return c.ServiceURL("instances", instanceId, "throttles", policyId)
 }
 
 func specRootURL(c *golangsdk.ServiceClient, instanceId, policyId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), policyId, "throttle-specials")
+	return c.ServiceURL("instances", instanceId, "throttles", policyId, "throttle-specials")
 }
 
 func specResourceURL(c *golangsdk.ServiceClient, instanceId, policyId, strategyId string) string {
-	return c.ServiceURL(buildRootPath(instanceId), policyId, "throttle-specials", strategyId)
+	return c.ServiceURL("instances", instanceId, "throttles", policyId, "throttle-specials", strategyId)
 }

--- a/openstack/dms/v1/groups/requests.go
+++ b/openstack/dms/v1/groups/requests.go
@@ -1,6 +1,8 @@
 package groups
 
 import (
+	"fmt"
+
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/pagination"
 )
@@ -53,7 +55,8 @@ func Delete(client *golangsdk.ServiceClient, queueID string, groupID string) (r 
 
 // List all the groups
 func List(client *golangsdk.ServiceClient, queueID string, includeDeadLetter bool) pagination.Pager {
-	url := listURL(client, queueID, includeDeadLetter)
+	url := listURL(client, queueID)
+	url += fmt.Sprintf("?include_deadletter=%t", includeDeadLetter)
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return GroupPage{pagination.SinglePageBase(r)}

--- a/openstack/dms/v1/groups/urls.go
+++ b/openstack/dms/v1/groups/urls.go
@@ -1,8 +1,6 @@
 package groups
 
 import (
-	"fmt"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -21,6 +19,6 @@ func deleteURL(client *golangsdk.ServiceClient, queueID string, groupID string) 
 }
 
 // listURL will build the list url of list function
-func listURL(client *golangsdk.ServiceClient, queueID string, includeDeadLetter bool) string {
-	return client.ServiceURL(resourcePathQueues, queueID, fmt.Sprintf("%s?include_deadletter=%t", resourcePathGroups, includeDeadLetter))
+func listURL(client *golangsdk.ServiceClient, queueID string) string {
+	return client.ServiceURL(resourcePathQueues, queueID, "resourcePathGroups")
 }

--- a/openstack/dms/v1/queues/requests.go
+++ b/openstack/dms/v1/queues/requests.go
@@ -1,6 +1,8 @@
 package queues
 
 import (
+	"fmt"
+
 	"github.com/chnsz/golangsdk"
 	"github.com/chnsz/golangsdk/pagination"
 )
@@ -80,13 +82,17 @@ func Delete(client *golangsdk.ServiceClient, id string) (r DeleteResult) {
 
 // Get a queue with detailed information by id
 func Get(client *golangsdk.ServiceClient, id string, includeDeadLetter bool) (r GetResult) {
-	_, r.Err = client.Get(getURL(client, id, includeDeadLetter), &r.Body, nil)
+	url := getURL(client, id)
+	url += fmt.Sprintf("?include_deadletter=%t", includeDeadLetter)
+
+	_, r.Err = client.Get(url, &r.Body, nil)
 	return
 }
 
 // List all the queues
 func List(client *golangsdk.ServiceClient, includeDeadLetter bool) pagination.Pager {
-	url := listURL(client, includeDeadLetter)
+	url := listURL(client)
+	url += fmt.Sprintf("?include_deadletter=%t", includeDeadLetter)
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return QueuePage{pagination.SinglePageBase(r)}

--- a/openstack/dms/v1/queues/urls.go
+++ b/openstack/dms/v1/queues/urls.go
@@ -1,8 +1,6 @@
 package queues
 
 import (
-	"fmt"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -20,11 +18,11 @@ func deleteURL(client *golangsdk.ServiceClient, id string) string {
 }
 
 // getURL will build the get url of get function
-func getURL(client *golangsdk.ServiceClient, id string, includeDeadLetter bool) string {
-	return client.ServiceURL(resourcePath, fmt.Sprintf("%s?include_deadletter=%t", id, includeDeadLetter))
+func getURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(resourcePath, id)
 }
 
 // listURL will build the list url of list function
-func listURL(client *golangsdk.ServiceClient, includeDeadLetter bool) string {
-	return client.ServiceURL(fmt.Sprintf("%s?include_deadletter=%t", resourcePath, includeDeadLetter))
+func listURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/mrs/v2/jobs/urls.go
+++ b/openstack/mrs/v2/jobs/urls.go
@@ -1,23 +1,17 @@
 package jobs
 
 import (
-	"fmt"
-
 	"github.com/chnsz/golangsdk"
 )
 
-func buildRootPath(clusterId string) string {
-	return fmt.Sprintf("clusters/%s/job-executions", clusterId)
-}
-
 func rootURL(c *golangsdk.ServiceClient, clusterId string) string {
-	return c.ServiceURL(buildRootPath(clusterId))
+	return c.ServiceURL("clusters", clusterId, "job-executions")
 }
 
 func resourceURL(c *golangsdk.ServiceClient, clusterId, jobId string) string {
-	return c.ServiceURL(buildRootPath(clusterId), jobId)
+	return c.ServiceURL("clusters", clusterId, "job-executions", jobId)
 }
 
 func deleteURL(c *golangsdk.ServiceClient, clusterId string) string {
-	return c.ServiceURL(buildRootPath(clusterId), "batch-delete")
+	return c.ServiceURL("clusters", clusterId, "job-executions", "batch-delete")
 }

--- a/openstack/networking/v2/extensions/elbaas/backendmember/requests.go
+++ b/openstack/networking/v2/extensions/elbaas/backendmember/requests.go
@@ -2,6 +2,8 @@ package backendmember
 
 import (
 	//"fmt"
+	"fmt"
+
 	"github.com/chnsz/golangsdk"
 	//"github.com/chnsz/golangsdk/pagination"
 )
@@ -104,6 +106,9 @@ func Remove(c *golangsdk.ServiceClient, listener_id string, id string) (r Remove
 
 // Get retrieves a particular Health Monitor based on its unique ID.
 func Get(c *golangsdk.ServiceClient, listener_id, id string) (r GetResult) {
-	_, r.Err = c.Get(resourceURL(c, listener_id, id), &r.Body, nil)
+	url := resourceURL(c, listener_id)
+	url += fmt.Sprintf("?id=%s", id)
+
+	_, r.Err = c.Get(url, &r.Body, nil)
 	return
 }

--- a/openstack/networking/v2/extensions/elbaas/backendmember/urls.go
+++ b/openstack/networking/v2/extensions/elbaas/backendmember/urls.go
@@ -15,6 +15,6 @@ func removeURL(c *golangsdk.ServiceClient, listener_id string) string {
 	return c.ServiceURL(rootPath, resourcePath, listener_id, "members", "action")
 }
 
-func resourceURL(c *golangsdk.ServiceClient, listener_id string, id string) string {
-	return c.ServiceURL(rootPath, resourcePath, listener_id, "members?id="+id)
+func resourceURL(c *golangsdk.ServiceClient, listener_id string) string {
+	return c.ServiceURL(rootPath, resourcePath, listener_id, "members")
 }

--- a/openstack/rds/v1/flavors/requests.go
+++ b/openstack/rds/v1/flavors/requests.go
@@ -1,6 +1,8 @@
 package flavors
 
 import (
+	"fmt"
+
 	"github.com/chnsz/golangsdk"
 )
 
@@ -10,8 +12,9 @@ var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
 
 //list the flavors informations about a specified id of database
 func List(client *golangsdk.ServiceClient, dataStoreID string, region string) (r ListResult) {
-
-	_, r.Err = client.Get(listURL(client, dataStoreID, region), &r.Body, &golangsdk.RequestOpts{
+	url := listURL(client)
+	url += fmt.Sprintf("?dbId=%s&region=%s", dataStoreID, region)
+	_, r.Err = client.Get(url, &r.Body, &golangsdk.RequestOpts{
 		OkCodes:     []int{200},
 		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
 	})

--- a/openstack/rds/v1/flavors/urls.go
+++ b/openstack/rds/v1/flavors/urls.go
@@ -2,7 +2,6 @@ package flavors
 
 import "github.com/chnsz/golangsdk"
 
-func listURL(c *golangsdk.ServiceClient, dataStoreID string, region string) string {
-
-	return c.ResourceBaseURL() + "flavors?dbId=" + dataStoreID + "&region=" + region
+func listURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("flavors")
 }

--- a/openstack/taurusdb/v3/instances/results_job.go
+++ b/openstack/taurusdb/v3/instances/results_job.go
@@ -41,7 +41,9 @@ func (r JobResult) ExtractJobStatus() (*JobStatus, error) {
 func WaitForJobSuccess(client *golangsdk.ServiceClient, secs int, jobID string) error {
 	return golangsdk.WaitFor(secs, func() (bool, error) {
 		job_status := new(JobStatus)
-		_, err := client.Get(jobURL(client, jobID), &job_status, &golangsdk.RequestOpts{
+		url := jobURL(client)
+		url += fmt.Sprintf("?id=%s", jobID)
+		_, err := client.Get(url, &job_status, &golangsdk.RequestOpts{
 			MoreHeaders: requestOpts.MoreHeaders,
 		})
 		time.Sleep(15 * time.Second)
@@ -54,7 +56,7 @@ func WaitForJobSuccess(client *golangsdk.ServiceClient, secs int, jobID string) 
 			return true, nil
 		}
 		if job.Status == "Failed" {
-			err = fmt.Errorf("Job failed: %s.\n", job.FailReason)
+			err = fmt.Errorf("Job failed: %s.", job.FailReason)
 			return false, err
 		}
 

--- a/openstack/taurusdb/v3/instances/urls.go
+++ b/openstack/taurusdb/v3/instances/urls.go
@@ -50,8 +50,8 @@ func actionURL(c *golangsdk.ServiceClient, instanceID string) string {
 	return c.ServiceURL("instances", instanceID, "action")
 }
 
-func jobURL(sc *golangsdk.ServiceClient, jobId string) string {
-	return sc.ServiceURL("jobs?id=" + jobId)
+func jobURL(sc *golangsdk.ServiceClient) string {
+	return sc.ServiceURL("jobs")
 }
 
 func listDehURL(c *golangsdk.ServiceClient) string {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There are some non-standard usages in urls.go files, which make it impossible to parse right API url

1.  use client.ServiceURL(...)  to replace the functions which use fmt.sprintf to build URL path.
2.  the functions arguments which have query params, remove params to requests.go.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
