### PR TITLE
feat(secgroup/rule): add new ver.1 sdk support

### DIFF
--- a/openstack/networking/v1/security/rules/requests.go
+++ b/openstack/networking/v1/security/rules/requests.go
@@ -1,0 +1,120 @@
+package rules
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is a struct which will be used to create a new security group rule.
+type CreateOpts struct {
+	// Specifies the security group ID.
+	SecurityGroupId string `json:"security_group_id" required:"true"`
+	// Provides supplementary information about the security group rule.
+	// The value can contain no more than 255 characters, including letters and digits.
+	Description string `json:"description,omitempty"`
+	// Specifies the direction of access control.
+	// Possible values are as follows:
+	//   egress
+	//   ingress
+	Direction string `json:"direction" required:"true"`
+	// Specifies the IP protocol version. The value can be IPv4 or IPv6. The default value is IPv4.
+	Ethertype string `json:"ethertype,omitempty"`
+	// Specifies the protocol type. The value can be icmp, tcp, or udp.
+	// If the parameter is left blank, all protocols are supported.
+	Protocol string `json:"protocol,omitempty"`
+	// Specifies the start port number.
+	// The value ranges from 1 to 65535.
+	// The value cannot be greater than the port_range_max value. An empty value indicates all ports.
+	PortRangeMin int `json:"port_range_min"`
+	// Specifies the end port number.
+	// The value ranges from 1 to 65535.
+	// The value cannot be smaller than the port_range_min value. An empty value indicates all ports.
+	PortRangeMax int `json:"port_range_max"`
+	// Specifies the remote IP address.
+	// If the access control direction is set to egress, the parameter specifies the source IP address.
+	// If the access control direction is set to ingress, the parameter specifies the destination IP address.
+	// The value can be in the CIDR format or IP addresses.
+	// The parameter is exclusive with parameter remote_group_id.
+	RemoteIpPrefix string `json:"remote_ip_prefix,omitempty"`
+	// Specifies the ID of the peer security group.
+	// The value is exclusive with parameter remote_ip_prefix.
+	RemoteGroupId string `json:"remote_group_id,omitempty"`
+}
+
+// Create is a method to create a new security group rule.
+func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*SecurityGroupRule, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "security_group_rule")
+	if err != nil {
+		return nil, err
+	}
+
+	var rst golangsdk.Result
+	_, err = c.Post(rootURL(c), b, &rst.Body, nil)
+	if err == nil {
+		var r SecurityGroupRule
+		rst.ExtractIntoStructPtr(&r, "security_group_rule")
+		return &r, nil
+	}
+	return nil, err
+}
+
+// Get is a method to obtain the security group rule detail.
+func Get(c *golangsdk.ServiceClient, ruleId string) (*SecurityGroupRule, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(resourceURL(c, ruleId), &rst.Body, nil)
+	if err == nil {
+		var r SecurityGroupRule
+		rst.ExtractIntoStructPtr(&r, "security_group_rule")
+		return &r, nil
+	}
+	return nil, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Specifies a resource ID for pagination query, indicating that the query starts from the next record of the
+	// specified resource ID. This parameter can work together with the parameter limit.
+	//   1. If parameters marker and limit are not passed, all resource records will be returned.
+	//   2. If the parameter marker is not passed and the value of parameter limit is set to 10, the first 10 resource
+	//     records will be returned.
+	//   3. If the value of the parameter marker is set to the resource ID of the 10th record and the value of parameter
+	//     limit is set to 10, the 11th to 20th resource records will be returned.
+	//   4. If the value of the parameter marker is set to the resource ID of the 10th record and the parameter limit is
+	//     not passed, resource records starting from the 11th records (including 11th) will be returned.
+	Marker string `q:"marker"`
+	// Specifies the number of records that will be returned on each page. The value is from 0 to intmax.
+	// limit can be used together with marker. For details, see the parameter description of marker.
+	Limit int `q:"limit"`
+	// Specifies the security group ID.
+	SecurityGroupId string `q:"security_group_id"`
+	// Specifies the project ID.
+	ProjectId string `q:"project_id"`
+}
+
+// List is a method to obtain the list of the security group rules.
+func List(c *golangsdk.ServiceClient, opts ListOpts) ([]SecurityGroupRule, error) {
+	url := rootURL(c)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := SecurityGroupRulePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractSecurityGroupRules(pages)
+}
+
+// Delete is a method to delete an existing security group rule.
+func Delete(c *golangsdk.ServiceClient, securityGroupRuleId string) *golangsdk.ErrResult {
+	var r golangsdk.ErrResult
+	_, r.Err = c.Delete(resourceURL(c, securityGroupRuleId), nil)
+	return &r
+}

--- a/openstack/networking/v1/security/rules/results.go
+++ b/openstack/networking/v1/security/rules/results.go
@@ -1,0 +1,72 @@
+package rules
+
+import "github.com/chnsz/golangsdk/pagination"
+
+// SecurityGroupRule is a struct that represents the detail of the security group rule.
+type SecurityGroupRule struct {
+	// Specifies the security group rule ID, which uniquely identifies the security group rule.
+	ID string `json:"id"`
+	// Provides supplementary information about the security group rule.
+	// The value can contain no more than 255 characters, including letters and digits.
+	Description string `json:"description"`
+	// Specifies the security group ID, which uniquely identifies the security group.
+	SecurityGroupId string `json:"security_group_id"`
+	// Specifies the direction of access control.
+	// Possible values are as follows:
+	//   egress
+	//   ingress
+	Direction string `json:"direction"`
+	// Specifies the protocol type. The value can be icmp, tcp, udp, icmpv6 or protocol number.
+	// If the parameter is left blank, all protocols are supported.
+	// When the protocol is icmpv6, the network type should be IPv6.
+	// when the protocol is icmp, the network type should be IPv4.
+	Protocol string `json:"protocol"`
+	// Specifies the IP protocol version. The value can be IPv4 or IPv6.
+	Ethertype string `json:"ethertype"`
+	// Specifies the start port number.
+	// The value ranges from 1 to 65535.
+	// The value cannot be greater than the port_range_max value. An empty value indicates all ports.
+	PortRangeMin int `json:"port_range_min"`
+	// Specifies the end port number.
+	// The value ranges from 1 to 65535.
+	// The value cannot be smaller than the port_range_min value. An empty value indicates all ports.
+	PortRangeMax int `json:"port_range_max"`
+	// Specifies the remote IP address.
+	// If the access control direction is set to egress, the parameter specifies the source IP address.
+	// If the access control direction is set to ingress, the parameter specifies the destination IP address.
+	// The value can be in the CIDR format or IP addresses.
+	// The parameter is exclusive with parameter remote_group_id.
+	RemoteIpPrefix string `json:"remote_ip_prefix"`
+	// Specifies the ID of the peer security group.
+	// The value is exclusive with parameter remote_ip_prefix.
+	RemoteGroupId string `json:"remote_group_id"`
+}
+
+type SecurityGroupRulePage struct {
+	pagination.MarkerPageBase
+}
+
+// LastMarker method returns the last security group rule ID in a SecurityGroupRulePage.
+func (p SecurityGroupRulePage) LastMarker() (string, error) {
+	secgroups, err := ExtractSecurityGroupRules(p)
+	if err != nil {
+		return "", err
+	}
+	if len(secgroups) == 0 {
+		return "", nil
+	}
+	return secgroups[len(secgroups)-1].ID, nil
+}
+
+// IsEmpty method checks whether the current SecurityGroupRulePage is empty.
+func (p SecurityGroupRulePage) IsEmpty() (bool, error) {
+	secgroups, err := ExtractSecurityGroupRules(p)
+	return len(secgroups) == 0, err
+}
+
+// ExtractSecurityGroupRules is a method to extract the list of security group rule details.
+func ExtractSecurityGroupRules(r pagination.Page) ([]SecurityGroupRule, error) {
+	var s []SecurityGroupRule
+	r.(SecurityGroupRulePage).Result.ExtractIntoSlicePtr(&s, "security_group_rules")
+	return s, nil
+}

--- a/openstack/networking/v1/security/rules/urls.go
+++ b/openstack/networking/v1/security/rules/urls.go
@@ -1,0 +1,11 @@
+package rules
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("security-group-rules")
+}
+
+func resourceURL(c *golangsdk.ServiceClient, ruleId string) string {
+	return c.ServiceURL("security-group-rules", ruleId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Due to ver.3 APIs of Security Group Rule are not supported in some regions, like `ap-southeast-2`. So, we need to support an older version (ver.3) of the API.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. add new ver.1 sdk support.
```
