### PR TITLE
chore: remove strings.replace in urls.go

### DIFF
--- a/openstack/compute/v2/extensions/floatingips/urls.go
+++ b/openstack/compute/v2/extensions/floatingips/urls.go
@@ -25,7 +25,7 @@ func deleteURL(c *golangsdk.ServiceClient, id string) string {
 }
 
 func serverURL(c *golangsdk.ServiceClient, serverID string) string {
-	return c.ServiceURL("servers/" + serverID + "/action")
+	return c.ServiceURL("servers", serverID, "action")
 }
 
 func associateURL(c *golangsdk.ServiceClient, serverID string) string {

--- a/openstack/dcs/v1/availablezones/urls.go
+++ b/openstack/dcs/v1/availablezones/urls.go
@@ -1,8 +1,6 @@
 package availablezones
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -11,6 +9,5 @@ const resourcePath = "availableZones"
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dcs/v1/instances/urls.go
+++ b/openstack/dcs/v1/instances/urls.go
@@ -9,34 +9,34 @@ const extendPath = "extend"
 
 // createURL will build the rest query url of creation
 func createURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
 // deleteURL will build the url of deletion
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 // updateURL will build the url of update
-func updateURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(resourcePath, id)
+func updateURL(client *golangsdk.ServiceClient, id string) string {
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 // passwordURL will build the password update function
 func passwordURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id, passwordPath)
+	return client.ServiceURL(client.ProjectID, resourcePath, id, passwordPath)
 }
 
 // extendURL will build the extend update function
 func extendURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id, extendPath)
+	return client.ServiceURL(client.ProjectID, resourcePath, id, extendPath)
 }
 
 func listURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }

--- a/openstack/dcs/v1/maintainwindows/urls.go
+++ b/openstack/dcs/v1/maintainwindows/urls.go
@@ -1,8 +1,6 @@
 package maintainwindows
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -11,6 +9,5 @@ const resourcePath = "instances/maintain-windows"
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dcs/v1/products/urls.go
+++ b/openstack/dcs/v1/products/urls.go
@@ -1,8 +1,6 @@
 package products
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -11,6 +9,5 @@ const resourcePath = "products"
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dcs/v2/availablezones/urls.go
+++ b/openstack/dcs/v2/availablezones/urls.go
@@ -1,8 +1,6 @@
 package availablezones
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -10,6 +8,5 @@ const resourcePath = "available-zones"
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectId from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dcs/v2/flavors/urls.go
+++ b/openstack/dcs/v2/flavors/urls.go
@@ -6,5 +6,5 @@ import (
 
 // listURL will build the get url of List function
 func listURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL("flavors")
+	return client.ServiceURL(client.ProjectID, "flavors")
 }

--- a/openstack/dcs/v2/instances/urls.go
+++ b/openstack/dcs/v2/instances/urls.go
@@ -3,17 +3,17 @@ package instances
 import "github.com/chnsz/golangsdk"
 
 func rootURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL("instances")
+	return c.ServiceURL(c.ProjectID, "instances")
 }
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL("instances", id)
+	return c.ServiceURL(c.ProjectID, "instances", id)
 }
 
 func resizeResourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL("instances", id, "resize")
+	return c.ServiceURL(c.ProjectID, "instances", id, "resize")
 }
 
 func updatePasswordURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL("instances", id, "password")
+	return c.ServiceURL(c.ProjectID, "instances", id, "password")
 }

--- a/openstack/dcs/v2/maintainwindows/urls.go
+++ b/openstack/dcs/v2/maintainwindows/urls.go
@@ -1,8 +1,6 @@
 package maintainwindows
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -11,6 +9,5 @@ const resourcePath = "instances/maintain-windows"
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dcs/v2/tags/urls.go
+++ b/openstack/dcs/v2/tags/urls.go
@@ -3,13 +3,13 @@ package tags
 import "github.com/chnsz/golangsdk"
 
 func resourceURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL("instances", id, "tags")
+	return c.ServiceURL(c.ProjectID, "instances", id, "tags")
 }
 
 func actionURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL("dcs", id, "tags", "action")
+	return c.ServiceURL(c.ProjectID, "dcs", id, "tags", "action")
 }
 
 func listURL(c *golangsdk.ServiceClient) string {
-	return c.ServiceURL("dcs", "tags")
+	return c.ServiceURL(c.ProjectID, "dcs", "tags")
 }

--- a/openstack/dcs/v2/whitelists/urls.go
+++ b/openstack/dcs/v2/whitelists/urls.go
@@ -7,5 +7,5 @@ const resourcePath = "instance"
 // resourceURL will build the url of put and get request url
 // url: client.Endpoint/instance/{instance_id}/whitelist
 func resourceURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id, "whitelist")
+	return client.ServiceURL(client.ProjectID, resourcePath, id, "whitelist")
 }

--- a/openstack/dms/v1/availablezones/urls.go
+++ b/openstack/dms/v1/availablezones/urls.go
@@ -1,8 +1,6 @@
 package availablezones
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -11,6 +9,5 @@ const resourcePath = "availableZones"
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dms/v1/groups/urls.go
+++ b/openstack/dms/v1/groups/urls.go
@@ -10,15 +10,15 @@ const resourcePathGroups = "groups"
 
 // createURL will build the rest query url of creation
 func createURL(client *golangsdk.ServiceClient, queueID string) string {
-	return client.ServiceURL(resourcePathQueues, queueID, resourcePathGroups)
+	return client.ServiceURL(client.ProjectID, resourcePathQueues, queueID, resourcePathGroups)
 }
 
 // deleteURL will build the url of deletion
 func deleteURL(client *golangsdk.ServiceClient, queueID string, groupID string) string {
-	return client.ServiceURL(resourcePathQueues, queueID, resourcePathGroups, groupID)
+	return client.ServiceURL(client.ProjectID, resourcePathQueues, queueID, resourcePathGroups, groupID)
 }
 
 // listURL will build the list url of list function
 func listURL(client *golangsdk.ServiceClient, queueID string) string {
-	return client.ServiceURL(resourcePathQueues, queueID, "resourcePathGroups")
+	return client.ServiceURL(client.ProjectID, resourcePathQueues, queueID, "resourcePathGroups")
 }

--- a/openstack/dms/v1/instances/urls.go
+++ b/openstack/dms/v1/instances/urls.go
@@ -7,24 +7,24 @@ const resourcePath = "instances"
 
 // createURL will build the rest query url of creation
 func createURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
 // deleteURL will build the url of deletion
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 // updateURL will build the url of update
 func updateURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(resourcePath, id)
+	return c.ServiceURL(c.ProjectID, resourcePath, id)
 }
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 func listURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }

--- a/openstack/dms/v1/maintainwindows/urls.go
+++ b/openstack/dms/v1/maintainwindows/urls.go
@@ -1,8 +1,6 @@
 package maintainwindows
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -11,6 +9,5 @@ const resourcePath = "instances/maintain-windows"
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dms/v1/products/requests.go
+++ b/openstack/dms/v1/products/requests.go
@@ -6,6 +6,10 @@ import (
 
 // Get products
 func Get(client *golangsdk.ServiceClient, engine string) (r GetResult) {
-	_, r.Err = client.Get(getURL(client, engine), &r.Body, nil)
+	url := getURL(client)
+	if engine != "" {
+		url = url + "?engine=" + engine
+	}
+	_, r.Err = client.Get(url, &r.Body, nil)
 	return
 }

--- a/openstack/dms/v1/products/urls.go
+++ b/openstack/dms/v1/products/urls.go
@@ -1,8 +1,6 @@
 package products
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -10,7 +8,6 @@ import (
 const resourcePath = "products"
 
 // getURL will build the get url of get function
-func getURL(client *golangsdk.ServiceClient, engine string) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath+"?engine="+engine), "/"+client.ProjectID, "", -1)
+func getURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dms/v1/queues/urls.go
+++ b/openstack/dms/v1/queues/urls.go
@@ -9,20 +9,20 @@ const resourcePath = "queues"
 
 // createURL will build the rest query url of creation
 func createURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
 // deleteURL will build the url of deletion
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 // listURL will build the list url of list function
 func listURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }

--- a/openstack/dms/v1/topics/urls.go
+++ b/openstack/dms/v1/topics/urls.go
@@ -11,10 +11,10 @@ const (
 
 // rootURL will build the url of create, update and list
 func rootURL(client *golangsdk.ServiceClient, instanceID string) string {
-	return client.ServiceURL(resourcePath, instanceID, topicPath)
+	return client.ServiceURL(client.ProjectID, resourcePath, instanceID, topicPath)
 }
 
 // deleteURL will build the url of delete
 func deleteURL(client *golangsdk.ServiceClient, instanceID string) string {
-	return client.ServiceURL(resourcePath, instanceID, topicPath, "delete")
+	return client.ServiceURL(client.ProjectID, resourcePath, instanceID, topicPath, "delete")
 }

--- a/openstack/dms/v2/availablezones/urls.go
+++ b/openstack/dms/v2/availablezones/urls.go
@@ -1,8 +1,6 @@
 package availablezones
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -11,6 +9,5 @@ const resourcePath = "available-zones"
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dms/v2/kafka/instances/urls.go
+++ b/openstack/dms/v2/kafka/instances/urls.go
@@ -7,28 +7,28 @@ const resourcePath = "instances"
 
 // createURL will build the rest query url of creation
 func createURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
 // deleteURL will build the url of deletion
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 // updateURL will build the url of update
 func updateURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(resourcePath, id)
+	return c.ServiceURL(c.ProjectID, resourcePath, id)
 }
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 func listURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
 func extend(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id, "extend")
+	return client.ServiceURL(client.ProjectID, resourcePath, id, "extend")
 }

--- a/openstack/dms/v2/kafka/topics/urls.go
+++ b/openstack/dms/v2/kafka/topics/urls.go
@@ -11,15 +11,15 @@ const (
 
 // rootURL will build the url of create, update and list
 func rootURL(client *golangsdk.ServiceClient, instanceID string) string {
-	return client.ServiceURL(resourcePath, instanceID, topicPath)
+	return client.ServiceURL(client.ProjectID, resourcePath, instanceID, topicPath)
 }
 
 // getURL will build the url of get
 func getURL(client *golangsdk.ServiceClient, instanceID, topic string) string {
-	return client.ServiceURL(resourcePath, instanceID, "management", topicPath, topic)
+	return client.ServiceURL(client.ProjectID, resourcePath, instanceID, "management", topicPath, topic)
 }
 
 // deleteURL will build the url of delete
 func deleteURL(client *golangsdk.ServiceClient, instanceID string) string {
-	return client.ServiceURL(resourcePath, instanceID, topicPath, "delete")
+	return client.ServiceURL(client.ProjectID, resourcePath, instanceID, topicPath, "delete")
 }

--- a/openstack/dms/v2/maintainwindows/urls.go
+++ b/openstack/dms/v2/maintainwindows/urls.go
@@ -1,8 +1,6 @@
 package maintainwindows
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -11,6 +9,5 @@ const resourcePath = "instances/maintain-windows"
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dms/v2/products/urls.go
+++ b/openstack/dms/v2/products/urls.go
@@ -1,8 +1,6 @@
 package products
 
 import (
-	"strings"
-
 	"github.com/chnsz/golangsdk"
 )
 
@@ -10,6 +8,5 @@ import (
 const resourcePath = "products"
 
 func getURL(client *golangsdk.ServiceClient) string {
-	// remove projectid from endpoint
-	return strings.Replace(client.ServiceURL(resourcePath), "/"+client.ProjectID, "", -1)
+	return client.ServiceURL(resourcePath)
 }

--- a/openstack/dms/v2/rabbitmq/instances/urls.go
+++ b/openstack/dms/v2/rabbitmq/instances/urls.go
@@ -7,24 +7,24 @@ const resourcePath = "instances"
 
 // createURL will build the rest query url of creation
 func createURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }
 
 // deleteURL will build the url of deletion
 func deleteURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 // updateURL will build the url of update
 func updateURL(c *golangsdk.ServiceClient, id string) string {
-	return c.ServiceURL(resourcePath, id)
+	return c.ServiceURL(c.ProjectID, resourcePath, id)
 }
 
 // getURL will build the get url of get function
 func getURL(client *golangsdk.ServiceClient, id string) string {
-	return client.ServiceURL(resourcePath, id)
+	return client.ServiceURL(client.ProjectID, resourcePath, id)
 }
 
 func listURL(client *golangsdk.ServiceClient) string {
-	return client.ServiceURL(resourcePath)
+	return client.ServiceURL(client.ProjectID, resourcePath)
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
There are some non-standard usages in urls.go files, which makes it impossible to parse the right API URL.
1. config dcs,dms client without projectID in provider, so remove strings.replace from urls.go, and add projectId to some func

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
