### PR TITLE
fix(secgroup/rule): fix port null value exception

### DIFF
--- a/openstack/networking/v1/security/rules/requests.go
+++ b/openstack/networking/v1/security/rules/requests.go
@@ -25,11 +25,11 @@ type CreateOpts struct {
 	// Specifies the start port number.
 	// The value ranges from 1 to 65535.
 	// The value cannot be greater than the port_range_max value. An empty value indicates all ports.
-	PortRangeMin int `json:"port_range_min"`
+	PortRangeMin int `json:"port_range_min,omitempty"`
 	// Specifies the end port number.
 	// The value ranges from 1 to 65535.
 	// The value cannot be smaller than the port_range_min value. An empty value indicates all ports.
-	PortRangeMax int `json:"port_range_max"`
+	PortRangeMax int `json:"port_range_max,omitempty"`
 	// Specifies the remote IP address.
 	// If the access control direction is set to egress, the parameter specifies the source IP address.
 	// If the access control direction is set to ingress, the parameter specifies the destination IP address.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The port range parameters are missing omitempty behavior.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. fix port null value exception.
```
