### PR TITLE
fix(apig/egress): rename extract method and support a new one

### DIFF
--- a/openstack/apigw/dedicated/v2/instances/results.go
+++ b/openstack/apigw/dedicated/v2/instances/results.go
@@ -202,13 +202,21 @@ type Egress struct {
 	BandwidthSize    int    `json:"bandwidthSize"`
 }
 
-// Call its Extract method to interpret it as a Egress.
-func (r EgressResult) Extract() (*Egress, error) {
+// ExtractStr is a method to interpret a json string as an Egress.
+// This is a temporary solution to the API problem.
+func (r EgressResult) ExtractStr() (*Egress, error) {
 	var s Egress
 	if r.Err != nil {
 		return &s, r.Err
 	}
 	err := json.Unmarshal([]byte(r.Body.(string)), &s)
+	return &s, err
+}
+
+// ExtractStr is a method to interpret the response body as an Egress.
+func (r EgressResult) Extract() (*Egress, error) {
+	var s Egress
+	err := r.ExtractInto(&s)
 	return &s, err
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The response of `UpdateEgressBandwidth()` method is a string, to interpret it, we support a `Extract()` method to handle it.
But this method is not available for the response body of the `EnableEgressAccess()` method.
```
Unable to parse JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. add a new method to interpret structure and rename the old one.
```
