### PR TITLE
fix(apig/egress): fix the assertion failure panic

### DIFF
--- a/openstack/apigw/dedicated/v2/instances/results.go
+++ b/openstack/apigw/dedicated/v2/instances/results.go
@@ -180,12 +180,12 @@ type DeleteResult struct {
 
 // EnableEgressResult represents the result of a EnableEgressAccess operation.
 type EnableEgressResult struct {
-	EgressResult
+	golangsdk.Result
 }
 
 // UdpateEgressResult represents the result of a UpdateEgressBandwidth operation.
 type UdpateEgressResult struct {
-	EgressResult
+	golangsdk.Result
 }
 
 type EgressResult struct {
@@ -202,13 +202,25 @@ type Egress struct {
 	BandwidthSize    int    `json:"bandwidthSize"`
 }
 
-// Call its Extract method to interpret it as a Egress.
-func (r EgressResult) Extract() (*Egress, error) {
+// Extract is a method to interpret the response body or json string as an Egress.
+func (r UdpateEgressResult) Extract() (*Egress, error) {
 	var s Egress
 	if r.Err != nil {
 		return &s, r.Err
 	}
-	err := json.Unmarshal([]byte(r.Body.(string)), &s)
+	body, ok := r.Body.(string)
+	if ok {
+		err := json.Unmarshal([]byte(body), &s)
+		return &s, err
+	}
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// Extract is a method to interpret the response body as an Egress.
+func (r EnableEgressResult) Extract() (*Egress, error) {
+	var s Egress
+	err := r.ExtractInto(&s)
 	return &s, err
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Since the return Body of the Post method and the Put method are different, the result should be separated.
The response of `UpdateEgressBandwidth()` method is a string, to interpret it, we support a `Extract()` method to handle it.
But this method is not available for the response body of the `EnableEgressAccess()` method.
```
Unable to parse JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. separate two 'Extract()' methods.
2. add assertion failure handling logic in 'Extract()' method that update method result.
```
