### PR TITLE
feat(servicestage): add new metadata sdk support

### DIFF
--- a/openstack/servicestage/v2/metadata/requests.go
+++ b/openstack/servicestage/v2/metadata/requests.go
@@ -1,0 +1,33 @@
+package metadata
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// ListRuntimes is a method to query the list of the runtimes.
+func ListRuntimes(c *golangsdk.ServiceClient) ([]Runtime, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(runtimeURL(c), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	var r []Runtime
+	err = rst.ExtractIntoSlicePtr(&r, "runtimes")
+	return r, err
+}
+
+// ListFlavors is a method to query the list of the flavors.
+func ListFlavors(c *golangsdk.ServiceClient) ([]Flavor, error) {
+	var rst golangsdk.Result
+	_, err := c.Get(flavorURL(c), &rst.Body, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+
+	var r []Flavor
+	err = rst.ExtractIntoSlicePtr(&r, "flavors")
+	return r, err
+}

--- a/openstack/servicestage/v2/metadata/results.go
+++ b/openstack/servicestage/v2/metadata/results.go
@@ -1,0 +1,33 @@
+package metadata
+
+// Runtime is the structure that represents the detail of the component runtime.
+type Runtime struct {
+	// Type.
+	Type string `json:"type_name"`
+	// Display name.
+	DisplayName string `json:"display_name"`
+	// Default container port.
+	ContainerDefaultPort int `json:"container_default_port"`
+	// Type description.
+	TypeDesc string `json:"type_desc"`
+}
+
+// Flavor is the structure that represents the flavor detail of the application resource.
+type Flavor struct {
+	// Flavor ID.
+	ID string `json:"flavor_id"`
+	// Storage size.
+	StorageSize string `json:"storage_size"`
+	// CPU limit.
+	NumCpu string `json:"num_cpu"`
+	// Initial CPU value.
+	NumCpuInit string `json:"num_cpu_init"`
+	// Memory limit.
+	MemorySize string `json:"memory_size"`
+	// Initial memory value.
+	MemorySizeInit string `json:"memory_size_init"`
+	// Label.
+	Label string `json:"label"`
+	// Whether resource specifications are customized.
+	Custom bool `json:"custom"`
+}

--- a/openstack/servicestage/v2/metadata/urls.go
+++ b/openstack/servicestage/v2/metadata/urls.go
@@ -1,0 +1,13 @@
+package metadata
+
+import "github.com/chnsz/golangsdk"
+
+const rootPath = "cas/metadata"
+
+func runtimeURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, "runtimes")
+}
+
+func flavorURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL(rootPath, "flavors")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The metadata sdk is used to query component runtimes and resource flavors of ServiceStage service.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. support new sdk package of ServiceStage metadata.
```
