### PR TITLE
feat(cbr/vault): add new function to extract vault orders

### DIFF
--- a/openstack/cbr/v3/vaults/results.go
+++ b/openstack/cbr/v3/vaults/results.go
@@ -81,6 +81,27 @@ func (r commonResult) Extract() (*Vault, error) {
 	return s.Vault, err
 }
 
+type OrderResp struct {
+	ErrText string  `json:"errText"`
+	ErrCode string  `json:"error_code"`
+	RetCode int     `json:"retCode"`
+	Orders  []Order `json:"orders"`
+}
+
+type Order struct {
+	CloudServiceId     string   `json:"cloudServiceId"`
+	ID                 string   `json:"orderId"`
+	ReserveInstanceIds []string `json:"reserveInstanceIds"`
+	ResourceId         string   `json:"resourceId"`
+	SubscribeResult    string   `json:"subscribeResult"`
+}
+
+func (r CreateResult) ExtractOrder() (*OrderResp, error) {
+	var s OrderResp
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
 type AssociateResourcesResult struct {
 	golangsdk.Result
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add new structure and function to extract vault orders.
The API response of prepaid order is:
```
{
  "errText": "success",
  "error_code": "0",
  "orders": [
    {
      "cloudServiceId": null,
      "orderId": "CS2206061640RCV6T",
      "reserveInstanceIds": [],
      "resourceId": "377538e1-7684-4705-9745-d8f4bc60a9c3",
      "subscribeResult": null
    }
  ],
  "retCode": 0
}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. add new structure and function to extract vault orders.
```
