### PR TITLE
feat(evs/attach): add an error structure

### DIFF
--- a/openstack/ecs/v1/block_devices/results.go
+++ b/openstack/ecs/v1/block_devices/results.go
@@ -64,3 +64,15 @@ func (r GetResult) Extract() (*VolumeAttachment, error) {
 func (r GetResult) ExtractInto(v interface{}) error {
 	return r.Result.ExtractIntoStructPtr(v, "volumeAttachment")
 }
+
+type ErrorResponse struct {
+	// Response error.
+	Error Error `json:"error"`
+}
+
+type Error struct {
+	// Error code.
+	Code string `json:"code"`
+	// Error message.
+	Message string `json:"message"`
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When we get the volume under the specified instance, if the volume has been deleted, an error occurs.
```
{
  "error": {
    "code": "Ecs.1000",
    "message": "{\"itemNotFound\": {\"message\": \"No volume Block Device Mapping with id bf70bd77-38dd-4db3-b473-31db1afc4733.\", \"code\": 404}}"
  }
}
```
Now we support a structure to parsing it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. support an error structure.
```
