### PR TITLE
feat(fgs/trigger): add an error structure

### DIFF
--- a/openstack/fgs/v2/trigger/results.go
+++ b/openstack/fgs/v2/trigger/results.go
@@ -58,3 +58,10 @@ func ExtractList(r pagination.Page) ([]Trigger, error) {
 	err := (r.(TriggerPage)).ExtractInto(&s)
 	return s, err
 }
+
+type Error struct {
+	// Error code, e.g. "FSS.0500"
+	Code string `json:"error_code"`
+	// Error message, e.g. "Error getting associated function"
+	Message string `json:"error_msg"`
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
When we get the trigger under the specified function, if the function or trigger has been deleted, an error occurs.
```
Error: error retrieving FunctionGraph trigger: Internal Server Error: [GET https://functiongraph.cn-north-4.myhuaweicloud.com/v2/0970dd7a1300f5672ff2c003c60ae115/fgs/triggers/urn:fss:cn-north-4:0970dd7a1300f5672ff2c003c60ae115:function:default:script_fgs_triggers_function], error message: {
│  "error_code": "FSS.0500",
│  "error_msg": "Error getting associated function"
│ }
```
Now we support a error structure and parse it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. support an error structure.
```
