### PR TITLE
fix(configuration): allow empty structure when body building

### DIFF
--- a/openstack/servicestage/v2/instances/requests.go
+++ b/openstack/servicestage/v2/instances/requests.go
@@ -36,7 +36,7 @@ type CreateOpts struct {
 	Artifacts map[string]Artifact `json:"artifacts,omitempty"`
 	// Configuration parameters, such as environment variables, deployment configurations, and O&M monitoring.
 	// By default, this parameter is left blank.
-	Configuration *Configuration `json:"configuration,omitempty"`
+	Configuration Configuration `json:"configuration,omitempty"`
 	// Description. The value can contain up to 128 characters.
 	Description string `json:"description,omitempty"`
 	// External network access.
@@ -354,7 +354,7 @@ type UpdateOpts struct {
 	Artifacts map[string]Artifact `json:"artifacts,omitempty"`
 	// Configuration parameters, such as environment variables, deployment configurations, and O&M monitoring.
 	// By default, this parameter is left blank.
-	Configuration *Configuration `json:"configuration,omitempty"`
+	Configuration Configuration `json:"configuration,omitempty"`
 	// Description. The value can contain up to 128 characters.
 	Description *string `json:"description,omitempty"`
 	// External network access.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
According to the current structure using, the configuration structure must be provided even it is empty. Otherwise, the component will fail to be deployed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. replace structure pointer with normal structure.
```
