### PR TITLE
feat: fix(env/variable): update response structures

### DIFF
--- a/openstack/servicestage/v2/instances/results.go
+++ b/openstack/servicestage/v2/instances/results.go
@@ -47,17 +47,30 @@ type Instance struct {
 // ConfigurationResp is an object represents the configuration details of the deployment.
 type ConfigurationResp struct {
 	// Environment variable.
-	EnvVariables []Variable `json:"env,omitempty"`
+	EnvVariables []VariableResp `json:"env"`
 	// Data storage configuration.
-	Storages []StorageResp `json:"storage,omitempty"`
+	Storages []StorageResp `json:"storage"`
 	// Upgrade policy.
-	Strategy StrategyResp `json:"strategy,omitempty"`
+	Strategy StrategyResp `json:"strategy"`
 	// Lifecycle.
-	Lifecycle LifecycleResp `json:"lifecycle,omitempty"`
+	Lifecycle LifecycleResp `json:"lifecycle"`
 	// Scheduling policy.
-	Scheduler SchedulerResp `json:"scheduler,omitempty"`
+	Scheduler SchedulerResp `json:"scheduler"`
 	// Health check.
-	Probe ProbeResp `json:"probes,omitempty"`
+	Probe ProbeResp `json:"probes"`
+}
+
+// VariableResp is an object represents the detail of the environment variable.
+
+type VariableResp struct {
+	// Whether variable is internal variable.
+	Internal bool `json:"internal"`
+	// Environment variable name.
+	// The value contains 1 to 64 characters, including letters, digits, underscores (_), hyphens (-), and dots (.),
+	// and cannot start with a digit.
+	Name string `json:"name"`
+	// Environment variable value.
+	Value string `json:"value"`
 }
 
 // StorageResp is an object represents the storage configuration of the deployment.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- The `omitempty` tag is unnecessary if the structure is using for API response.
- Now we have a new parameter `internal` to mark whether variable is system variable.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. remove the omitempty tag from response structure
2. support a new env structure
```
