### PR TITLE
feat(servicestage/job): support a list method and deprecate get method

### DIFF
--- a/openstack/servicestage/v2/jobs/requests.go
+++ b/openstack/servicestage/v2/jobs/requests.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
 )
 
 var requestOpts = golangsdk.RequestOpts{
@@ -9,10 +10,46 @@ var requestOpts = golangsdk.RequestOpts{
 }
 
 // Get is a method to obtain the details of a specified deployment job using its ID.
+//
+// Deprecated: Please use the List method to query task details because of the Get method can only obtain maximum of 20
+// results of task (The first page).
 func Get(c *golangsdk.ServiceClient, jobId string) (*JobResp, error) {
 	var r JobResp
 	_, err := c.Get(rootURL(c, jobId), &r, &golangsdk.RequestOpts{
 		MoreHeaders: requestOpts.MoreHeaders,
 	})
 	return &r, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Instance ID of the component.
+	InstanceId string `q:"instance_id"`
+	// Number of records to be queried.
+	// Default value: 20
+	Limit int `q:"limit"`
+	// The offset number.
+	Offset int `q:"offset"`
+	// Descending or ascending order.
+	Desc string `q:"desc"`
+}
+
+// List is a method to query the list of the deployment task using given ID and opts.
+func List(c *golangsdk.ServiceClient, jobId string, opts ListOpts) ([]Task, error) {
+	url := rootURL(c, jobId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := TaskPage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return ExtractTasks(pages)
 }

--- a/openstack/servicestage/v2/jobs/results.go
+++ b/openstack/servicestage/v2/jobs/results.go
@@ -1,5 +1,7 @@
 package jobs
 
+import "github.com/chnsz/golangsdk/pagination"
+
 // JobResp is the structure that represents the detail of the deployment job and task list.
 type JobResp struct {
 	// Number of tasks.
@@ -52,4 +54,22 @@ type Task struct {
 	Status string `json:"task_status"`
 	// Task type.
 	Type string `json:"task_type"`
+}
+
+// TaskPage is a single page maximum result representing a query by offset page.
+type TaskPage struct {
+	pagination.OffsetPageBase
+}
+
+// IsEmpty checks whether a TaskPage is empty.
+func (b TaskPage) IsEmpty() (bool, error) {
+	arr, err := ExtractTasks(b)
+	return len(arr) == 0, err
+}
+
+// ExtractTasks is a method to extract the list of task details for ServiceStage component.
+func ExtractTasks(r pagination.Page) ([]Task, error) {
+	var s []Task
+	err := r.(TaskPage).Result.ExtractIntoSlicePtr(&s, "tasks")
+	return s, err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The `Get` method can only query a maximum of 20 records for deployment task, that is, the content of one page and not satisfied with the existing scenario.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
