### PR TITLE
feat(dms/product): add new query method support

### DIFF
--- a/openstack/dms/v2/kafka/instances/requests.go
+++ b/openstack/dms/v2/kafka/instances/requests.go
@@ -34,15 +34,18 @@ type CreateOps struct {
 	// Indicates the version of a message engine.
 	EngineVersion string `json:"engine_version" required:"true"`
 
-	//Indicates the baseline bandwidth of a Kafka instance, that is,
-	//the maximum amount of data transferred per unit time. Unit: byte/s.
-	Specification string `json:"specification" required:"true"`
-
 	// Indicates the message storage space.
 	StorageSpace int `json:"storage_space" required:"true"`
 
-	//Indicates the maximum number of topics in a Kafka instance.
-	PartitionNum int `json:"partition_num" required:"true"`
+	// Indicates the baseline bandwidth of a Kafka instance, that is,
+	// the maximum amount of data transferred per unit time. Unit: byte/s.
+	Specification string `json:"specification,omitempty"`
+
+	// Indicates the maximum number of brokers in a Kafka instance.
+	BrokerNum int `json:"broker_num,omitempty"`
+
+	// Indicates the maximum number of topics in a Kafka instance.
+	PartitionNum int `json:"partition_num,omitempty"`
 
 	// Indicates a username.
 	// A username consists of 1 to 64 characters

--- a/openstack/dms/v2/kafka/instances/results.go
+++ b/openstack/dms/v2/kafka/instances/results.go
@@ -42,6 +42,7 @@ type Instance struct {
 	Specification              string             `json:"specification"`
 	StorageSpace               int                `json:"storage_space"`
 	PartitionNum               string             `json:"partition_num"`
+	BrokerNum                  int                `json:"broker_num"`
 	UsedStorageSpace           int                `json:"used_storage_space"`
 	ConnectAddress             string             `json:"connect_address"`
 	Port                       int                `json:"port"`

--- a/openstack/dms/v2/products/requests.go
+++ b/openstack/dms/v2/products/requests.go
@@ -7,6 +7,9 @@ import (
 )
 
 // Get products
+//
+// Deprecated: Please use the GetFlavor method to query product (new format) details of DMS kafka.
+// The old format is '00300-30308-0--0', but the new that we recommanded is 'c6.2u4g.cluster'.
 func Get(client *golangsdk.ServiceClient, engine string) (*GetResponse, error) {
 	if len(engine) == 0 {
 		return nil, fmt.Errorf("The parameter \"engine\" cannot be empty, it is required.")
@@ -22,4 +25,26 @@ func Get(client *golangsdk.ServiceClient, engine string) (*GetResponse, error) {
 		return &r, err
 	}
 	return nil, err
+}
+
+type ListOpts struct {
+	// The product ID.
+	ProductId string `q:"product_id"`
+}
+
+// List is a method to query the list of product details using given parameters.
+func List(c *golangsdk.ServiceClient, engineType string, opts ListOpts) (*ListResp, error) {
+	url := listURL(c, engineType)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var r ListResp
+	_, err = c.Get(url, &r, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &r, nil
 }

--- a/openstack/dms/v2/products/results.go
+++ b/openstack/dms/v2/products/results.go
@@ -56,3 +56,92 @@ type IO struct {
 	UnavailableZones []string `json:"unavailable_zones"`
 	VolumeType       string   `json:"volume_type"`
 }
+
+// ListResp is the structure that represents the request response of List method.
+type ListResp struct {
+	// The engine type of the DMS products.
+	Engine string `json:"engine"`
+	// The supported product version types.
+	Versions []string `json:"versions"`
+	// The list of product details.
+	Products []Product `json:"products"`
+}
+
+// Product is the structure that represents the details of the product specification.
+type Product struct {
+	// product type. The current product types are stand-alone and cluster.
+	Type string `json:"type"`
+	// Product ID.
+	ProductId string `json:"product_id"`
+	// The underlying resource type.
+	EcsFlavorId string `json:"ecs_flavor_id"`
+	// Billing type.
+	BillingCode string `json:"billing_code"`
+	// List of supported CPU architectures.
+	ArchTypes []string `json:"arch_types"`
+	// List of supported billing modes.
+	//   monthly: yearly/monthly type.
+	//   hourly: On-demand type.
+	ChargingModes []string `json:"charging_mode"`
+	// List of supported disk IO types.
+	IOs []IOEntity `json:"ios"`
+	// A list of features supported by the current specification instance.
+	SupportFeatures []SupportFeatureEntity `json:"support_features"`
+	// Properties of the current specification instance.
+	Properties PropertiesEntity `json:"properties"`
+}
+
+// IOEntity is the structure that represents the disk IO type information.
+type IOEntity struct {
+	// Disk IO encoding.
+	IoSpec string `json:"io_spec"`
+	// Disk type.
+	Type string `json:"type"`
+	// Availability Zone.
+	AvailableZones []string `json:"available_zones"`
+	// Unavailable zone.
+	UnavailableZones []string `json:"unavailable_zones"`
+}
+
+// SupportFeatureEntity is the structure that represents the features supported by the instance.
+type SupportFeatureEntity struct {
+	// function name.
+	Name string `json:"name"`
+	// Description of the function properties supported by the instance.
+	Properties SupportFeaturePropertiesEntity `json:"properties"`
+}
+
+// SupportFeaturePropertiesEntity is the structure that represents the description of the functional properties
+// supported by the instance.
+type SupportFeaturePropertiesEntity struct {
+	// The maximum number of tasks for the dump function.
+	MaxTask string `json:"max_task"`
+	// Minimum number of tasks for dump function.
+	MinTask string `json:"min_task"`
+	// Maximum number of nodes for dump function.
+	MaxNode string `json:"max_node"`
+	// Minimum number of nodes for dump function.
+	MinNode string `json:"min_node"`
+}
+
+// PropertiesEntity is the structure that represents the properties of the current specification instance.
+type PropertiesEntity struct {
+	// Maximum number of partitions per broker.
+	MaxPartitionPerBroker string `json:"max_partition_per_broker"`
+	// The maximum number of brokers.
+	MaxBroker string `json:"max_broker"`
+	// Maximum storage per node. The unit is GB.
+	MaxStoragePerNode string `json:"max_storage_per_node"`
+	// Maximum number of consumers per broker.
+	MaxConsumerPerBroker string `json:"max_consumer_per_broker"`
+	// The minimum number of brokers.
+	MinBroker string `json:"min_broker"`
+	// Maximum bandwidth per broker.
+	MaxBandwidthPerBroker string `json:"max_bandwidth_per_broker"`
+	// Minimum storage per node. The unit is GB.
+	MinStoragePerNode string `json:"min_storage_per_node"`
+	// Maximum TPS per Broker.
+	MaxTpsPerBroker string `json:"max_tps_per_broker"`
+	// Product ID alias.
+	ProductAlias string `json:"product_alias"`
+}

--- a/openstack/dms/v2/products/urls.go
+++ b/openstack/dms/v2/products/urls.go
@@ -10,3 +10,7 @@ const resourcePath = "products"
 func getURL(client *golangsdk.ServiceClient) string {
 	return client.ServiceURL(resourcePath)
 }
+
+func listURL(client *golangsdk.ServiceClient, engineType string) string {
+	return client.ServiceURL(engineType, resourcePath)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
- Support a new method to query products of the new format. (the old format is `00300-30308-0--0`, the new format is `c6.2u4g.cluster`).
- Add and update some parameters to support the creation of kafka instances with new format products.
  - **specification**: required -> optional
  - **partition_num**: required -> optional
  - new parameter **broker_num** and the behavior is optional

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. support a new method to query the new products for the new format.
2. add and update some parameters to support the creation of kafka instances for new format products.
```
