### PR TITLE
fix(secgroup): fix the incorrect parameter type for priority

### DIFF
--- a/openstack/networking/v3/security/groups/requests.go
+++ b/openstack/networking/v3/security/groups/requests.go
@@ -28,8 +28,8 @@ func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*SecurityGroup, error)
 	_, err = c.Post(rootURL(c), b, &rst.Body, nil)
 	if err == nil {
 		var r SecurityGroup
-		rst.ExtractIntoStructPtr(&r, "security_group")
-		return &r, nil
+		err := rst.ExtractIntoStructPtr(&r, "security_group")
+		return &r, err
 	}
 	return nil, err
 }
@@ -40,8 +40,8 @@ func Get(c *golangsdk.ServiceClient, securityGroupId string) (*SecurityGroup, er
 	_, err := c.Get(resourceURL(c, securityGroupId), &rst.Body, nil)
 	if err == nil {
 		var r SecurityGroup
-		rst.ExtractIntoStructPtr(&r, "security_group")
-		return &r, nil
+		err = rst.ExtractIntoStructPtr(&r, "security_group")
+		return &r, err
 	}
 	return nil, err
 }
@@ -117,8 +117,8 @@ func Update(c *golangsdk.ServiceClient, securityGroupId string, opts UpdateOpts)
 	_, err = c.Put(resourceURL(c, securityGroupId), b, &rst.Body, nil)
 	if err == nil {
 		var r SecurityGroup
-		rst.ExtractIntoStructPtr(&r, "security_group")
-		return &r, nil
+		err = rst.ExtractIntoStructPtr(&r, "security_group")
+		return &r, err
 	}
 	return nil, err
 }

--- a/openstack/networking/v3/security/groups/results.go
+++ b/openstack/networking/v3/security/groups/results.go
@@ -54,6 +54,6 @@ func (p SecurityGroupPage) IsEmpty() (bool, error) {
 // ExtractSecurityGroups is a method to extract the list of security group details.
 func ExtractSecurityGroups(r pagination.Page) ([]SecurityGroup, error) {
 	var s []SecurityGroup
-	r.(SecurityGroupPage).Result.ExtractIntoSlicePtr(&s, "security_groups")
-	return s, nil
+	err := r.(SecurityGroupPage).Result.ExtractIntoSlicePtr(&s, "security_groups")
+	return s, err
 }

--- a/openstack/networking/v3/security/rules/requests.go
+++ b/openstack/networking/v3/security/rules/requests.go
@@ -42,7 +42,7 @@ type CreateOpts struct {
 	Action string `json:"action,omitempty"`
 	// Specifies the ID of the peer security group.
 	// The value is exclusive with parameter remote_ip_prefix.
-	Priority string `json:"priority,omitempty"`
+	Priority int `json:"priority,omitempty"`
 }
 
 // Create is a method to create a new security group rule.

--- a/openstack/networking/v3/security/rules/requests.go
+++ b/openstack/networking/v3/security/rules/requests.go
@@ -56,8 +56,8 @@ func Create(c *golangsdk.ServiceClient, opts CreateOpts) (*SecurityGroupRule, er
 	_, err = c.Post(rootURL(c), b, &rst.Body, nil)
 	if err == nil {
 		var r SecurityGroupRule
-		rst.ExtractIntoStructPtr(&r, "security_group_rule")
-		return &r, nil
+		err = rst.ExtractIntoStructPtr(&r, "security_group_rule")
+		return &r, err
 	}
 	return nil, err
 }
@@ -68,8 +68,8 @@ func Get(c *golangsdk.ServiceClient, ruleId string) (*SecurityGroupRule, error) 
 	_, err := c.Get(resourceURL(c, ruleId), &rst.Body, nil)
 	if err == nil {
 		var r SecurityGroupRule
-		rst.ExtractIntoStructPtr(&r, "security_group_rule")
-		return &r, nil
+		err = rst.ExtractIntoStructPtr(&r, "security_group_rule")
+		return &r, err
 	}
 	return nil, err
 }

--- a/openstack/networking/v3/security/rules/results.go
+++ b/openstack/networking/v3/security/rules/results.go
@@ -33,7 +33,7 @@ type SecurityGroupRule struct {
 	Action string `json:"action"`
 	// Priority
 	// Value range: 1~100, 1 represents the highest priority.
-	Priority string `json:"priority"`
+	Priority int `json:"priority"`
 	// Specifies the remote IP address.
 	// If the access control direction is set to egress, the parameter specifies the source IP address.
 	// If the access control direction is set to ingress, the parameter specifies the destination IP address.

--- a/openstack/networking/v3/security/rules/results.go
+++ b/openstack/networking/v3/security/rules/results.go
@@ -78,6 +78,6 @@ func (p SecurityGroupRulePage) IsEmpty() (bool, error) {
 // ExtractSecurityGroupRules is a method to extract the list of security group rule details.
 func ExtractSecurityGroupRules(r pagination.Page) ([]SecurityGroupRule, error) {
 	var s []SecurityGroupRule
-	r.(SecurityGroupRulePage).Result.ExtractIntoSlicePtr(&s, "security_group_rules")
-	return s, nil
+	err := r.(SecurityGroupRulePage).Result.ExtractIntoSlicePtr(&s, "security_group_rules")
+	return s, err
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameter type of priority should be integer, but string.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. update the incorrect parameter type from string to int.
```
