### PR TITLE
feat(dds/instance): add job sdk and support modify method for port

### DIFF
--- a/openstack/dds/v3/instances/requests.go
+++ b/openstack/dds/v3/instances/requests.go
@@ -16,6 +16,7 @@ type CreateOpts struct {
 	SubnetId            string         `json:"subnet_id" required:"true"`
 	SecurityGroupId     string         `json:"security_group_id" required:"true"`
 	Password            string         `json:"password" required:"true"`
+	Port                string         `json:"port,omitempty"`
 	DiskEncryptionId    string         `json:"disk_encryption_id,omitempty"`
 	Ssl                 string         `json:"ssl_option,omitempty"`
 	Mode                string         `json:"mode" required:"true"`
@@ -191,4 +192,30 @@ func Update(client *golangsdk.ServiceClient, instanceId string, opts []UpdateOpt
 		}
 	}
 	return
+}
+
+var requestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// PortOpts is the structure required by the UpdatePort method to modify the database access port.
+type PortOpts struct {
+	Port int `json:"port"`
+}
+
+// UpdatePort is a method to update the database access port using given parameters.
+func UpdatePort(c *golangsdk.ServiceClient, instanceId string, port int) (*PortUpdateResp, error) {
+	opts := PortOpts{
+		Port: port,
+	}
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r PortUpdateResp
+	_, err = c.Post(portModifiedURL(c, instanceId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r, err
 }

--- a/openstack/dds/v3/instances/results.go
+++ b/openstack/dds/v3/instances/results.go
@@ -144,3 +144,11 @@ func ExtractInstances(r pagination.Page) (ListInstanceResponse, error) {
 	err := (r.(InstancePage)).ExtractInto(&s)
 	return s, err
 }
+
+// PortUpdateResp is the structure that represents the detail of the database user.
+type PortUpdateResp struct {
+	// Job ID.
+	JobId string `json:"job_id"`
+	// Database access port.
+	Port int `json:"port"`
+}

--- a/openstack/dds/v3/instances/urls.go
+++ b/openstack/dds/v3/instances/urls.go
@@ -17,3 +17,7 @@ func listURL(c *golangsdk.ServiceClient) string {
 func modifyURL(c *golangsdk.ServiceClient, serverID, action string) string {
 	return c.ServiceURL("instances", serverID, action)
 }
+
+func portModifiedURL(c *golangsdk.ServiceClient, instanceId string) string {
+	return c.ServiceURL("instances", instanceId, "modify-port")
+}

--- a/openstack/dds/v3/jobs/requests.go
+++ b/openstack/dds/v3/jobs/requests.go
@@ -1,0 +1,36 @@
+package jobs
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+var requestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// QueryOpts allows to filter list data using given parameters.
+type QueryOpts struct {
+	// Job ID.
+	JobId string `q:"id"`
+}
+
+// Get is a method to retrieves a particular job based on its unique ID.
+func Get(c *golangsdk.ServiceClient, jobId string) (*Job, error) {
+	opts := QueryOpts{
+		JobId: jobId,
+	}
+	url := rootURL(c)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	var r struct {
+		Job Job `json:"job"`
+	}
+	_, err = c.Get(url, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Job, err
+}

--- a/openstack/dds/v3/jobs/results.go
+++ b/openstack/dds/v3/jobs/results.go
@@ -1,0 +1,32 @@
+package jobs
+
+// Job is the structure that represents the detail of the process job.
+type Job struct {
+	// Job ID.
+	ID string `json:"id"`
+	// Job name.
+	Name string `json:"name"`
+	// Status info.
+	// + Running
+	// + Completed
+	// + Failed
+	Status string `json:"status"`
+	// Creation time, the format is "yyyy-mm-ddThh:mm:ssZ".
+	Created string `json:"created"`
+	// End time, the format is "yyyy-mm-ddThh:mm:ssZ".
+	Ended string `json:"ended"`
+	// The execution progress of the job.
+	Progress string `json:"progress"`
+	// The DDS instance info to which the job belongs.
+	Instance Instance `json:"instance"`
+	// Error information generated when the job fails to be executed.
+	FailReason string `json:"fail_reason"`
+}
+
+// Instance is the structure that represents the detail of the DDS instnace.
+type Instance struct {
+	// Instance ID.
+	ID string `json:"id"`
+	// Instance name.
+	Name string `json:"name"`
+}

--- a/openstack/dds/v3/jobs/urls.go
+++ b/openstack/dds/v3/jobs/urls.go
@@ -1,0 +1,7 @@
+package jobs
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("jobs")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The API has been support the port parameter for create and update method, but we were not supported.
To query the progress of the databse access port modifying, we need to add a job sdk.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. add job sdk and support modify method for port.
```
