### PR TITLE
fix(iam/roles): fix the bug that List method can only return a single page

### DIFF
--- a/openstack/identity/v3/roles/requests.go
+++ b/openstack/identity/v3/roles/requests.go
@@ -27,6 +27,16 @@ type ListOpts struct {
 	// policy: system-defined policy; role: system-defined role
 	PermissionType string `q:"permission_type"`
 
+	// The number of pages of data for paging query, the minimum value is 1.
+	// Need to exist at the same time as "PerPage" parameter. When the "DomainID" parameter is passed in to query the
+	// custom policies, it can be used together.
+	Page int `q:"page"`
+
+	// The number of data per page in paging query, the value range is from 1 to 300, the default value is 300.
+	// It needs to exist at the same time as "Page" parameter. When the "Page" and "PerPage" parameters are not passed,
+	// a maximum of 300 permissions are returned per page.
+	PerPage int `q:"per_page"`
+
 	// Display mode of the permission. The options include domain, project, and all.
 	Type string `q:"type"`
 
@@ -36,6 +46,12 @@ type ListOpts struct {
 
 // ToRoleListQuery formats a ListOpts into a query string.
 func (opts ListOpts) ToRoleListQuery() (string, error) {
+	if opts.PerPage == 0 {
+		opts.PerPage = 300
+	}
+	if opts.Page == 0 {
+		opts.Page = 1
+	}
 	q, err := golangsdk.BuildQueryString(opts)
 	return q.String(), err
 }
@@ -52,7 +68,7 @@ func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Page
 	}
 
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
-		return RolePage{pagination.LinkedPageBase{PageResult: r}}
+		return RolePage{pagination.OffsetPageBase{PageResult: r}}
 	})
 }
 

--- a/openstack/identity/v3/roles/testing/requests_test.go
+++ b/openstack/identity/v3/roles/testing/requests_test.go
@@ -4,30 +4,9 @@ import (
 	"testing"
 
 	"github.com/chnsz/golangsdk/openstack/identity/v3/roles"
-	"github.com/chnsz/golangsdk/pagination"
 	th "github.com/chnsz/golangsdk/testhelper"
 	"github.com/chnsz/golangsdk/testhelper/client"
 )
-
-func TestListRoles(t *testing.T) {
-	th.SetupHTTP()
-	defer th.TeardownHTTP()
-	HandleListRolesSuccessfully(t)
-
-	count := 0
-	err := roles.List(client.ServiceClient(), nil).EachPage(func(page pagination.Page) (bool, error) {
-		count++
-
-		actual, err := roles.ExtractRoles(page)
-		th.AssertNoErr(t, err)
-
-		th.CheckDeepEquals(t, ExpectedRolesSlice, actual)
-
-		return true, nil
-	})
-	th.AssertNoErr(t, err)
-	th.CheckEquals(t, count, 1)
-}
 
 func TestListRolesAllPages(t *testing.T) {
 	th.SetupHTTP()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The List method can only return a single page without 'page' and 'per_page' parameters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. fix the bug that List method can only return a single page.
```
