### PR TITLE
Networking resources tag filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/*.swp
 .idea
 .vscode
+.devcontainer

--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -41,10 +41,22 @@ type ListOpts struct {
 
 	//Specifies the ID of the VPC to which the subnet belongs.
 	VPC_ID string `q:"vpc_id"`
+
+	//Specifies tags subnets must match (returning those matching all tags).
+	Tags string `q:"tags"`
+
+	//Specifies tags subnets must match (returning those matching at least one of the tags).
+	TagsAny string `q:"tags-any"`
+
+	//Specifies tags subnets mustn't match (returning those missing all tags).
+	NotTags string `q:"not-tags"`
+
+	//Specifies tags subnets mustn't match (returning those missing at least one of the tags).
+	NotTagsAny string `q:"not-tags-any"`
 }
 
 func (opts ListOpts) hasQueryParameter() bool {
-	return opts.VPC_ID != ""
+	return opts.VPC_ID != "" || opts.Tags != "" || opts.TagsAny != "" || opts.NotTags != "" || opts.NotTagsAny != ""
 }
 
 // ToSubnetListQuery formats a ListOpts into a query string

--- a/openstack/networking/v1/subnets/requests.go
+++ b/openstack/networking/v1/subnets/requests.go
@@ -43,6 +43,10 @@ type ListOpts struct {
 	VPC_ID string `q:"vpc_id"`
 }
 
+func (opts ListOpts) hasQueryParameter() bool {
+	return opts.VPC_ID != ""
+}
+
 // ToSubnetListQuery formats a ListOpts into a query string
 func (opts ListOpts) ToSubnetListQuery() (string, error) {
 	q, err := golangsdk.BuildQueryString(opts)
@@ -61,7 +65,7 @@ func (opts ListOpts) ToSubnetListQuery() (string, error) {
 func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Subnet, error) {
 	url := rootURL(c)
 
-	if opts.VPC_ID != "" {
+	if opts.hasQueryParameter() {
 		query, err := opts.ToSubnetListQuery()
 		if err != nil {
 			return nil, err

--- a/openstack/networking/v1/subnets/testing/requests_test.go
+++ b/openstack/networking/v1/subnets/testing/requests_test.go
@@ -22,6 +22,18 @@ func listSubnets(t *testing.T, opts subnets.ListOpts, mock_json string, expected
 		if opts.VPC_ID != "" {
 			expected_args["vpc_id"] = opts.VPC_ID
 		}
+		if opts.Tags != "" {
+			expected_args["tags"] = opts.Tags
+		}
+		if opts.TagsAny != "" {
+			expected_args["tags-any"] = opts.TagsAny
+		}
+		if opts.NotTags != "" {
+			expected_args["not-tags"] = opts.NotTags
+		}
+		if opts.NotTagsAny != "" {
+			expected_args["not-tags-any"] = opts.NotTagsAny
+		}
 		th.TestFormValues(t, r, expected_args)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -109,6 +121,10 @@ func TestListSubnet(t *testing.T) {
 
 	listSubnets(t, subnets.ListOpts{}, subnet_mock, subnet_expected)
 	listSubnets(t, subnets.ListOpts{VPC_ID: "58c24204-170e-4ff0-9b42-c53cdea9239a"}, subnet_mock, subnet_expected)
+	listSubnets(t, subnets.ListOpts{Tags: "my-tag"}, subnet_mock, subnet_expected)
+	listSubnets(t, subnets.ListOpts{TagsAny: "my-tag"}, subnet_mock, subnet_expected)
+	listSubnets(t, subnets.ListOpts{NotTags: "my-tag"}, subnet_mock, subnet_expected)
+	listSubnets(t, subnets.ListOpts{NotTagsAny: "my-tag"}, subnet_mock, subnet_expected)
 }
 
 func TestGetSubnet(t *testing.T) {

--- a/openstack/networking/v1/subnets/testing/requests_test.go
+++ b/openstack/networking/v1/subnets/testing/requests_test.go
@@ -18,6 +18,12 @@ func listSubnets(t *testing.T, opts subnets.ListOpts, mock_json string, expected
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
+		expected_args := map[string]string{}
+		if opts.VPC_ID != "" {
+			expected_args["vpc_id"] = opts.VPC_ID
+		}
+		th.TestFormValues(t, r, expected_args)
+
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
@@ -102,6 +108,7 @@ func TestListSubnet(t *testing.T) {
 	}
 
 	listSubnets(t, subnets.ListOpts{}, subnet_mock, subnet_expected)
+	listSubnets(t, subnets.ListOpts{VPC_ID: "58c24204-170e-4ff0-9b42-c53cdea9239a"}, subnet_mock, subnet_expected)
 }
 
 func TestGetSubnet(t *testing.T) {

--- a/openstack/networking/v1/subnets/testing/requests_test.go
+++ b/openstack/networking/v1/subnets/testing/requests_test.go
@@ -10,7 +10,7 @@ import (
 	th "github.com/chnsz/golangsdk/testhelper"
 )
 
-func TestListSubnet(t *testing.T) {
+func listSubnets(t *testing.T, opts subnets.ListOpts, mock_json string, expected []subnets.Subnet) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -21,7 +21,19 @@ func TestListSubnet(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprintf(w, mock_json)
+	})
+
+	actual, err := subnets.List(fake.ServiceClient(), opts)
+	if err != nil {
+		t.Errorf("Failed to extract subnets: %v", err)
+	}
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestListSubnet(t *testing.T) {
+	subnet_mock := `
 {
     "subnets": [
         {
@@ -32,12 +44,12 @@ func TestListSubnet(t *testing.T) {
             "vpc_id": "58c24204-170e-4ff0-9b42-c53cdea9239a",
             "gateway_ip": "192.168.200.1",
             "dhcp_enable": true,
-			"primary_dns": "114.114.114.114",
-		    "secondary_dns": "114.114.115.115",
-		    "dnsList": [
-			  "114.114.114.114",
-			  "114.114.115.115"
-		    ],
+            "primary_dns": "114.114.114.114",
+            "secondary_dns": "114.114.115.115",
+            "dnsList": [
+              "114.114.114.114",
+              "114.114.115.115"
+            ],
             "neutron_subnet_id": "3d543273-31c3-41f8-b887-ed8c2c837578"
         },
         {
@@ -48,26 +60,19 @@ func TestListSubnet(t *testing.T) {
             "vpc_id": "58c24204-170e-4ff0-9b42-c53cdea9239a",
             "gateway_ip": "192.168.200.1",
             "dhcp_enable": true,
-			"primary_dns": "114.114.114.114",
-		    "secondary_dns": "114.114.115.115",
-		    "dnsList": [
-			  "114.114.114.114",
-			  "114.114.115.115"
-		    ],
+            "primary_dns": "114.114.114.114",
+            "secondary_dns": "114.114.115.115",
+            "dnsList": [
+              "114.114.114.114",
+              "114.114.115.115"
+            ],
             "neutron_subnet_id": "3d543273-31c3-41f8-b887-ed8c2c837578"
         }
     ]
 }
+		`
 
-		`)
-	})
-
-	actual, err := subnets.List(fake.ServiceClient(), subnets.ListOpts{})
-	if err != nil {
-		t.Errorf("Failed to extract subnets: %v", err)
-	}
-
-	expected := []subnets.Subnet{
+	subnet_expected := []subnets.Subnet{
 		{
 			Status:        "ACTIVE",
 			CIDR:          "192.168.200.0/24",
@@ -95,7 +100,8 @@ func TestListSubnet(t *testing.T) {
 			SubnetId:      "3d543273-31c3-41f8-b887-ed8c2c837578",
 		},
 	}
-	th.AssertDeepEquals(t, expected, actual)
+
+	listSubnets(t, subnets.ListOpts{}, subnet_mock, subnet_expected)
 }
 
 func TestGetSubnet(t *testing.T) {

--- a/openstack/networking/v1/vpcs/requests.go
+++ b/openstack/networking/v1/vpcs/requests.go
@@ -29,10 +29,22 @@ type ListOpts struct {
 
 	// Status indicates whether or not a vpc is currently operational.
 	Status string `json:"status"`
+
+	// Specifies tags VPCs must match (returning those matching all tags).
+	Tags string `q:"tags"`
+
+	// Specifies tags VPCs must match (returning those matching at least one of the tags).
+	TagsAny string `q:"tags-any"`
+
+	// Specifies tags VPCs mustn't match (returning those missing all tags).
+	NotTags string `q:"not-tags"`
+
+	// Specifies tags VPCs mustn't match (returning those missing at least one of the tags).
+	NotTagsAny string `q:"not-tags-any"`
 }
 
 func (opts ListOpts) hasQueryParameter() bool {
-	return opts.EnterpriseProjectID != ""
+	return opts.EnterpriseProjectID != "" || opts.Tags != "" || opts.TagsAny != "" || opts.NotTags != "" || opts.NotTagsAny != ""
 }
 
 // ToVpcListQuery formats a ListOpts into a query string
@@ -59,6 +71,7 @@ func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Vpc, error) {
 		}
 		url += query
 	}
+
 	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
 		return VpcPage{pagination.LinkedPageBase{PageResult: r}}
 	}).AllPages()

--- a/openstack/networking/v1/vpcs/requests.go
+++ b/openstack/networking/v1/vpcs/requests.go
@@ -31,6 +31,10 @@ type ListOpts struct {
 	Status string `json:"status"`
 }
 
+func (opts ListOpts) hasQueryParameter() bool {
+	return opts.EnterpriseProjectID != ""
+}
+
 // ToVpcListQuery formats a ListOpts into a query string
 func (opts ListOpts) ToVpcListQuery() (string, error) {
 	q, err := golangsdk.BuildQueryString(opts)
@@ -48,7 +52,7 @@ func (opts ListOpts) ToVpcListQuery() (string, error) {
 // tenant who submits the request, unless an admin user submits the request.
 func List(c *golangsdk.ServiceClient, opts ListOpts) ([]Vpc, error) {
 	url := rootURL(c)
-	if opts.EnterpriseProjectID != "" {
+	if opts.hasQueryParameter() {
 		query, err := opts.ToVpcListQuery()
 		if err != nil {
 			return nil, err

--- a/openstack/networking/v1/vpcs/testing/requests_test.go
+++ b/openstack/networking/v1/vpcs/testing/requests_test.go
@@ -22,6 +22,18 @@ func listVpcs(t *testing.T, opts vpcs.ListOpts, mock_json string, expected []vpc
 		if opts.EnterpriseProjectID != "" {
 			expected_args["enterprise_project_id"] = opts.EnterpriseProjectID
 		}
+		if opts.Tags != "" {
+			expected_args["tags"] = opts.Tags
+		}
+		if opts.TagsAny != "" {
+			expected_args["tags-any"] = opts.TagsAny
+		}
+		if opts.NotTags != "" {
+			expected_args["not-tags"] = opts.NotTags
+		}
+		if opts.NotTagsAny != "" {
+			expected_args["not-tags-any"] = opts.NotTagsAny
+		}
 		th.TestFormValues(t, r, expected_args)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -99,6 +111,10 @@ func TestListVpc(t *testing.T) {
 
 	listVpcs(t, vpcs.ListOpts{}, vpc_mock, vpc_expected)
 	listVpcs(t, vpcs.ListOpts{EnterpriseProjectID: "eproject_id"}, vpc_mock, vpc_expected)
+	listVpcs(t, vpcs.ListOpts{Tags: "my-tag"}, vpc_mock, vpc_expected)
+	listVpcs(t, vpcs.ListOpts{TagsAny: "my-tag"}, vpc_mock, vpc_expected)
+	listVpcs(t, vpcs.ListOpts{NotTags: "my-tag"}, vpc_mock, vpc_expected)
+	listVpcs(t, vpcs.ListOpts{NotTagsAny: "my-tag"}, vpc_mock, vpc_expected)
 }
 
 func TestGetVpc(t *testing.T) {

--- a/openstack/networking/v1/vpcs/testing/requests_test.go
+++ b/openstack/networking/v1/vpcs/testing/requests_test.go
@@ -18,6 +18,12 @@ func listVpcs(t *testing.T, opts vpcs.ListOpts, mock_json string, expected []vpc
 		th.TestMethod(t, r, "GET")
 		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
 
+		expected_args := map[string]string{}
+		if opts.EnterpriseProjectID != "" {
+			expected_args["enterprise_project_id"] = opts.EnterpriseProjectID
+		}
+		th.TestFormValues(t, r, expected_args)
+
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
@@ -92,6 +98,7 @@ func TestListVpc(t *testing.T) {
 	}
 
 	listVpcs(t, vpcs.ListOpts{}, vpc_mock, vpc_expected)
+	listVpcs(t, vpcs.ListOpts{EnterpriseProjectID: "eproject_id"}, vpc_mock, vpc_expected)
 }
 
 func TestGetVpc(t *testing.T) {

--- a/openstack/networking/v1/vpcs/testing/requests_test.go
+++ b/openstack/networking/v1/vpcs/testing/requests_test.go
@@ -10,7 +10,7 @@ import (
 	th "github.com/chnsz/golangsdk/testhelper"
 )
 
-func TestListVpc(t *testing.T) {
+func listVpcs(t *testing.T, opts vpcs.ListOpts, mock_json string, expected []vpcs.Vpc) {
 	th.SetupHTTP()
 	defer th.TeardownHTTP()
 
@@ -21,7 +21,19 @@ func TestListVpc(t *testing.T) {
 		w.Header().Add("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		fmt.Fprintf(w, `
+		fmt.Fprintf(w, mock_json)
+	})
+
+	actual, err := vpcs.List(fake.ServiceClient(), opts)
+	if err != nil {
+		t.Errorf("Failed to extract vpcs: %v", err)
+	}
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestListVpc(t *testing.T) {
+	vpc_mock := `
 {
     "vpcs": [
         {
@@ -50,17 +62,9 @@ func TestListVpc(t *testing.T) {
         }
     ]
 }
-			`)
-	})
+                       `
 
-	//count := 0
-
-	actual, err := vpcs.List(fake.ServiceClient(), vpcs.ListOpts{})
-	if err != nil {
-		t.Errorf("Failed to extract vpcs: %v", err)
-	}
-
-	expected := []vpcs.Vpc{
+	vpc_expected := []vpcs.Vpc{
 		{
 			Status:           "OK",
 			CIDR:             "192.168.0.0/16",
@@ -87,7 +91,7 @@ func TestListVpc(t *testing.T) {
 		},
 	}
 
-	th.AssertDeepEquals(t, expected, actual)
+	listVpcs(t, vpcs.ListOpts{}, vpc_mock, vpc_expected)
 }
 
 func TestGetVpc(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Tags request parameters to V1 VPC and subnet list requests.

fixes #236 

**Special notes for your reviewer**:
Expect similar PRs for other resources in the (near) future.

**Release note**:

```release-note
```
