### PR TITLE
feat(er): Four sdks are supported for ER service

### DIFF
--- a/openstack/er/v3/associations/requests.go
+++ b/openstack/er/v3/associations/requests.go
@@ -1,0 +1,107 @@
+package associations
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure used to create an association to a specified route table.
+type CreateOpts struct {
+	// The ID of the VPC attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// The export routing policy.
+	RoutePolicy ExportRoutePolicy `json:"route_policy,omitempty"`
+}
+
+// ExportRoutePolicy is an object that represents the configuration of the export routing policy.
+type ExportRoutePolicy struct {
+	// The export routing policy ID.
+	ExportPoilicyId string `json:"export_policy_id,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new association under a specified route table.
+func Create(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts CreateOpts) (*Association, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = client.Post(enableURL(client, instanceId, routeTableId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Association, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the association of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The list of attachment IDs, support for querying multiple associations.
+	AttachmentIds []string `q:"attachment_id"`
+	// The list of attachment resource types, support for querying multiple associations.
+	ResourceTypes []string `q:"resource_type"`
+	// The list of current status of the associations, support for querying multiple associations.
+	Statuses []string `q:"state"`
+	// The list of keyword to sort the associations result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the associations under specified route table using given parameters.
+func List(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts ListOpts) ([]Association, error) {
+	url := queryURL(client, instanceId, routeTableId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := AssociationPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractAssociations(pages)
+}
+
+// DeleteOpts is the structure used to remove an association from a specified route table.
+type DeleteOpts struct {
+	// The ID of the VPC attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// The export routing policy.
+	RoutePolicy ExportRoutePolicy `json:"route_policy,omitempty"`
+}
+
+// Delete is a method to remove an existing association from a specified route table.
+func Delete(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts DeleteOpts) error {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Post(disableURL(client, instanceId, routeTableId), b, nil,
+		&golangsdk.RequestOpts{
+			MoreHeaders: requestOpts.MoreHeaders,
+		})
+	return err
+}

--- a/openstack/er/v3/associations/results.go
+++ b/openstack/er/v3/associations/results.go
@@ -1,0 +1,92 @@
+package associations
+
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// createResp is the structure that represents the API response of the 'Create' method, which contains association
+// details and the request information.
+type createResp struct {
+	// The response detail of the association.
+	Association Association `json:"association"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// Association is the structure that represents the details of the association under route table.
+type Association struct {
+	// The ID of the association.
+	ID string `json:"id"`
+	// The ID of the route table to which the association belongs.
+	RouteTableId string `json:"route_table_id"`
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id"`
+	// The resource type for the corresponding attachment.
+	ResourceType string `json:"resource_type"`
+	// The resource ID for the corresponding attachment.
+	ResourceId string `json:"resource_id"`
+	// The configuration of the export routing policy.
+	RoutePolicy ExportRoutePolicy `json:"route_policy"`
+	// The current status of the association.
+	Status string `json:"state"`
+	// The creation time of the association.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the association.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// listResp is the structure that represents the API response of the 'List' method, which contains association list,
+// page details and the request information.
+type listResp struct {
+	// The list of the associations.
+	Associations []Association `json:"associations"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// pageInfo is the structure that represents the page information.
+type pageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the associations in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// AssociationPage represents the response pages of the List method.
+type AssociationPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no association.
+func (r AssociationPage) IsEmpty() (bool, error) {
+	resp, err := extractAssociations(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r AssociationPage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listResp
+	err := r.(AssociationPage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// ExtractAssociations is a method which to extract the response to a association list.
+func extractAssociations(r pagination.Page) ([]Association, error) {
+	var s listResp
+	err := r.(AssociationPage).Result.ExtractInto(&s)
+	return s.Associations, err
+}

--- a/openstack/er/v3/associations/urls.go
+++ b/openstack/er/v3/associations/urls.go
@@ -1,0 +1,15 @@
+package associations
+
+import "github.com/chnsz/golangsdk"
+
+func enableURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "associate")
+}
+
+func queryURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "associations")
+}
+
+func disableURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "disassociate")
+}

--- a/openstack/er/v3/propagations/requests.go
+++ b/openstack/er/v3/propagations/requests.go
@@ -1,0 +1,108 @@
+package propagations
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure used to create a propagation to a specified route table.
+type CreateOpts struct {
+	// The ID of the VPC attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// The export routing policy.
+	RoutePolicy ImportRoutePolicy `json:"route_policy,omitempty"`
+}
+
+// ImportRoutePolicy is an object that represents the configuration of the import routing policy.
+type ImportRoutePolicy struct {
+	// The import routing policy ID.
+	ImportPoilicyId string `json:"import_policy_id,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new propagation under the route table.
+func Create(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts CreateOpts) (*Propagation, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = client.Post(enableURL(client, instanceId, routeTableId), b, &r,
+		&golangsdk.RequestOpts{
+			MoreHeaders: requestOpts.MoreHeaders,
+		})
+	return &r.Propagation, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the propagation of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The list of attachment IDs, support for querying multiple propagations.
+	AttachmentIds []string `q:"attachment_id"`
+	// The list of attachment resource types, support for querying multiple propagations.
+	ResourceTypes []string `q:"resource_type"`
+	// The list of current status of the propagations, support for querying multiple propagations.
+	Statuses []string `q:"state"`
+	// The list of keyword to sort the propagations result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the propagations under specified route table using given opts.
+func List(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts ListOpts) ([]Propagation, error) {
+	url := queryURL(client, instanceId, routeTableId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := PropagationPage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractPropagations(pages)
+}
+
+// DeleteOpts is the structure used to remove a propagation from a specified route table.
+type DeleteOpts struct {
+	// The ID of the VPC attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// The export routing policy.
+	RoutePolicy ImportRoutePolicy `json:"route_policy,omitempty"`
+}
+
+// Delete is a method to remove an existing propagation from a specified route table.
+func Delete(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts DeleteOpts) error {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Post(disableURL(client, instanceId, routeTableId), b, nil,
+		&golangsdk.RequestOpts{
+			MoreHeaders: requestOpts.MoreHeaders,
+		})
+	return err
+}

--- a/openstack/er/v3/propagations/results.go
+++ b/openstack/er/v3/propagations/results.go
@@ -1,0 +1,96 @@
+package propagations
+
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// createResp is the structure that represents the API response of the 'Create' method, which contains propagation
+// details and the request information.
+type createResp struct {
+	// The response detail of the propagation.
+	Propagation Propagation `json:"propagation"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// Propagation is the structure that represents the details of the propagation under route table.
+type Propagation struct {
+	// The ID of the propagation.
+	ID string `json:"id"`
+	// The ID of the project where the propagation is located.
+	ProjectId string `json:"project_id"`
+	// The ID of the ER instance to which the propagation belongs.
+	InstanceId string `json:"er_id"`
+	// The ID of the route table to which the association belongs.
+	RouteTableId string `json:"route_table_id"`
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id"`
+	// The resource type for the corresponding attachment.
+	ResourceType string `json:"resource_type"`
+	// The resource ID for the corresponding attachment.
+	ResourceId string `json:"resource_id"`
+	// The configuration of the import routing policy.
+	RoutePolicy ImportRoutePolicy `json:"route_policy"`
+	// The current status of the propagation.
+	Status string `json:"state"`
+	// The creation time of the propagation.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the propagation.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// listResp is the structure that represents the API response of the 'List' method, which contains propagation list,
+// page details and the request information.
+type listResp struct {
+	// The list of the propagations.
+	Propagations []Propagation `json:"propagations"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// pageInfo is the structure that represents the page information.
+type pageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the propagations in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// PropagationPage represents the response pages of the List method.
+type PropagationPage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no propagation.
+func (r PropagationPage) IsEmpty() (bool, error) {
+	resp, err := extractPropagations(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r PropagationPage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listResp
+	err := r.(PropagationPage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// ExtractPropagations is a method which to extract the response to a propagation list.
+func extractPropagations(r pagination.Page) ([]Propagation, error) {
+	var s listResp
+	err := r.(PropagationPage).Result.ExtractInto(&s)
+	return s.Propagations, err
+}

--- a/openstack/er/v3/propagations/urls.go
+++ b/openstack/er/v3/propagations/urls.go
@@ -1,0 +1,15 @@
+package propagations
+
+import "github.com/chnsz/golangsdk"
+
+func enableURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "enable-propagations")
+}
+
+func queryURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "propagations")
+}
+
+func disableURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId, "disable-propagations")
+}

--- a/openstack/er/v3/routes/requests.go
+++ b/openstack/er/v3/routes/requests.go
@@ -1,0 +1,120 @@
+package routes
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure used to create the route under a specified route table.
+type CreateOpts struct {
+	// The destination of the route.
+	Destination string `json:"destination" required:"true"`
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// Whether route is the black hole route.
+	IsBlackHole *bool `json:"is_blackhole,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new route under a specified route table.
+func Create(client *golangsdk.ServiceClient, routeTableId string, opts CreateOpts) (*Route, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "route")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = client.Post(rootURL(client, routeTableId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Route, err
+}
+
+// Get is a method to obtain the route details using given parameters.
+func Get(client *golangsdk.ServiceClient, routeTableId, routeId string) (*Route, error) {
+	var r getResp
+	_, err := client.Get(resourceURL(client, routeId, routeTableId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Route, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the route of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The list of the destinations, support for querying multiple routes.
+	Destination []string `q:"destination"`
+	// The list of attachment IDs, support for querying multiple routes.
+	AttachmentIds []string `json:"attachment_id"`
+	// The list of attachment resource types, support for querying multiple routes.
+	ResourceType []string `json:"resource_type"`
+	// The list of keyword to sort the associations result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the routes under a specified route table using given parameters.
+func List(client *golangsdk.ServiceClient, routeTableId string, opts ListOpts) ([]Route, error) {
+	url := rootURL(client, routeTableId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := RoutePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractRoutes(pages)
+}
+
+// UpdateOpts is the structure used to update the route configuration.
+type UpdateOpts struct {
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id,omitempty"`
+	// Whether route is the black hole route.
+	IsBlackHole *bool `json:"is_blackhole,omitempty"`
+}
+
+// Update is a method to update route configuration using update option.
+func Update(client *golangsdk.ServiceClient, routeTableId, routeId string, opts UpdateOpts) (*Route, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "route_table")
+	if err != nil {
+		return nil, err
+	}
+
+	var r updateResp
+	_, err = client.Put(resourceURL(client, routeTableId, routeId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Route, err
+}
+
+// Delete is a method to remove an existing route from a specified route table.
+func Delete(client *golangsdk.ServiceClient, routeTableId, routeId string) error {
+	_, err := client.Delete(resourceURL(client, routeTableId, routeId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/openstack/er/v3/routes/results.go
+++ b/openstack/er/v3/routes/results.go
@@ -1,0 +1,120 @@
+package routes
+
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// createResp is the structure that represents the API response of the 'Create' method, which contains route details and
+// the request information.
+type createResp struct {
+	// The response detail of the route.
+	Route Route `json:"route"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// Route is the structure that represents the details of the route under a specified route table.
+type Route struct {
+	// The ID of the route.
+	ID string `json:"id"`
+	// The type of the route.
+	Type string `json:"type"`
+	// Whether route is the black hole route.
+	IsBlackHole bool `json:"is_blackhole"`
+	// The destination of the route.
+	Destination string `json:"destination"`
+	// The corresponding attachments.
+	Attachments []Attachment `json:"attachments"`
+	// The ID of the route table to which the route belongs.
+	RouteTableId string `json:"route_table_id"`
+	// The current status of the route.
+	Status string `json:"state"`
+	// The creation time of the association.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the association.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// Attachment is an object that represents the details of the corresponding route.
+type Attachment struct {
+	// The resource ID for the corresponding attachment.
+	ResourceId string `json:"resource_id"`
+	// The resource type for the corresponding attachment.
+	ResourceType string `json:"resource_type"`
+	// The ID of the corresponding attachment.
+	AttachmentId string `json:"attachment_id"`
+}
+
+// getResp is the structure that represents the API response of the 'Get' method, which contains route details and the
+// request information.
+type getResp struct {
+	// The response detail of the route.
+	Route Route `json:"route"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// listResp is the structure that represents the API response of the 'List' method, which contains route list, page
+// details and the request information.
+type listResp struct {
+	// The list of the routes.
+	Routes []Route `json:"routes"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// pageInfo is the structure that represents the page information.
+type pageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the associations in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// RoutePage represents the response pages of the List method.
+type RoutePage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no route.
+func (r RoutePage) IsEmpty() (bool, error) {
+	resp, err := extractRoutes(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r RoutePage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractRoutes is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listResp
+	err := r.(RoutePage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// extractRoutes is a method which to extract the response to a route list.
+func extractRoutes(r pagination.Page) ([]Route, error) {
+	var s listResp
+	err := r.(RoutePage).Result.ExtractInto(&s)
+	return s.Routes, err
+}
+
+// updateResp is the structure that represents the API response of the 'Update' method, which contains route details and
+// the request information.
+type updateResp struct {
+	// The response detail of the route.
+	Route Route `json:"route"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}

--- a/openstack/er/v3/routes/utls.go
+++ b/openstack/er/v3/routes/utls.go
@@ -1,0 +1,11 @@
+package routes
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient, routeTableId string) string {
+	return client.ServiceURL("enterprise-router/route-tables", routeTableId, "static-routes")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, routeId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router/route-tables", routeTableId, "static-routes", routeId)
+}

--- a/openstack/er/v3/routetables/requests.go
+++ b/openstack/er/v3/routetables/requests.go
@@ -1,0 +1,137 @@
+package routetables
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// CreateOpts is the structure required by the 'Create' method to create a route table under a specified ER instance.
+type CreateOpts struct {
+	// The name of the route table.
+	// The value can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-)
+	// and dots (.) are allowed.
+	Name string `json:"name" required:"true"`
+	// The description of the route table.
+	// The value contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+	Description string `json:"description,omitempty"`
+	// The configuration of the BGP route selection.
+	BgpOptions BgpOptions `json:"bgp_options,omitempty"`
+	// The key/value pairs to associate with the route table.
+	Tags []tags.ResourceTag `json:"tags,omitempty"`
+}
+
+// BgpOptions is an object that represents the BGP configuration for routing.
+type BgpOptions struct {
+	// Whether the AS path attributes of the routes are not compared during load balancing.
+	LoadBalancingAsPathIgnore *bool `json:"load_balancing_as_path_ignore,omitempty"`
+	// Whether the AS path attributes of the same length are not compared during load balancing.
+	LoadBalancingAsPathRelax *bool `json:"load_balancing_as_path_relax,omitempty"`
+}
+
+var requestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json", "X-Language": "en-us"},
+}
+
+// Create is a method to create a new route table under a specified ER instance using given parameters.
+func Create(client *golangsdk.ServiceClient, instanceId string, opts CreateOpts) (*RouteTable, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "route_table")
+	if err != nil {
+		return nil, err
+	}
+
+	var r createResp
+	_, err = client.Post(rootURL(client, instanceId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.RouteTable, err
+}
+
+// Get is a method to obtain the route table details under a specified ER instance.
+func Get(client *golangsdk.ServiceClient, instanceId, routeTableId string) (*RouteTable, error) {
+	var r getResp
+	_, err := client.Get(resourceURL(client, instanceId, routeTableId), &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.RouteTable, err
+}
+
+// ListOpts allows to filter list data using given parameters.
+type ListOpts struct {
+	// Number of records to be queried.
+	// The valid value is range from 0 to 2000.
+	Limit int `q:"limit"`
+	// The ID of the route table of the last record on the previous page.
+	// If it is empty, it is the first page of the query.
+	// This parameter must be used together with limit.
+	// The valid value is range from 1 to 128.
+	Marker string `q:"marker"`
+	// The list of current status of the route tables, support for querying multiple route tables.
+	Status []string `q:"state"`
+	// Whether this route table is the default association route table.
+	IsDefaultAssociation bool `q:"is_default_association"`
+	// Whether this route table is the default propagation route table.
+	IsDefaultPropagation bool `q:"is_default_propagation"`
+	// The list of keyword to sort the route tables result, sort by ID by default.
+	// The optional values are as follow:
+	// + id
+	// + name
+	// + state
+	SortKey []string `q:"sort_key"`
+	// The returned results are arranged in ascending or descending order, the default is asc.
+	SortDir []string `q:"sort_dir"`
+}
+
+// List is a method to query the list of the route tables under a specified ER instance using given parameters.
+func List(client *golangsdk.ServiceClient, instanceId string, opts ListOpts) ([]RouteTable, error) {
+	url := rootURL(client, instanceId)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := RouteTablePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	return extractRouteTables(pages)
+}
+
+// UpdateOpts is the structure required by the 'Update' method to update the route table configuration.
+type UpdateOpts struct {
+	// The name of the route table.
+	// The value can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-)
+	// and dots (.) are allowed.
+	Name string `json:"name,omitempty"`
+	// The description of the route table.
+	// The value contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+	Description *string `json:"description,omitempty"`
+}
+
+// Update is a method to update the route table under a specified ER instance using parameters.
+func Update(client *golangsdk.ServiceClient, instanceId, routeTableId string, opts UpdateOpts) (*RouteTable, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "route_table")
+	if err != nil {
+		return nil, err
+	}
+
+	var r updateResp
+	_, err = client.Put(resourceURL(client, instanceId, routeTableId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.RouteTable, err
+}
+
+// Delete is a method to remove an existing route table under a specified ER instance.
+func Delete(client *golangsdk.ServiceClient, instanceId, routeTableId string) error {
+	_, err := client.Delete(resourceURL(client, instanceId, routeTableId), &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return err
+}

--- a/openstack/er/v3/routetables/results.go
+++ b/openstack/er/v3/routetables/results.go
@@ -1,0 +1,116 @@
+package routetables
+
+import (
+	"github.com/chnsz/golangsdk/openstack/common/tags"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// createResp is the structure that represents the API response of the 'Create' method, which contains route table
+// details and the request information.
+type createResp struct {
+	// The response detail of the route table.
+	RouteTable RouteTable `json:"route_table"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// RouteTable is the structure that represents the details of the route table for ER service.
+type RouteTable struct {
+	// The ID of the route table.
+	ID string `json:"id"`
+	// The name of the route table.
+	// The value can contain 1 to 64 characters, only english and chinese letters, digits, underscore (_), hyphens (-)
+	// and dots (.) are allowed.
+	Name string `json:"name"`
+	// The description of the route table.
+	// The value contain a maximum of 255 characters, and the angle brackets (< and >) are not allowed.
+	Description string `json:"description"`
+	// The configuration of the BGP route selection.
+	BgpOptions BgpOptions `json:"bgp_options"`
+	// The key/value pairs to associate with the route table.
+	Tags []tags.ResourceTag `json:"tags"`
+	// Whether this route table is the default association route table.
+	IsDefaultAssociation bool `json:"is_default_association"`
+	// Whether this route table is the default propagation route table.
+	IsDefaultPropagation bool `json:"is_default_propagation"`
+	// The current status of the route table.
+	Status string `json:"state"`
+	// The creation time of the route table.
+	CreatedAt string `json:"created_at"`
+	// The last update time of the route table.
+	UpdatedAt string `json:"updated_at"`
+}
+
+// getResp is the structure that represents the API response of the 'Get' method, which contains route table details and
+// the request information.
+type getResp struct {
+	// The response detail of the route table.
+	RouteTable RouteTable `json:"route_table"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}
+
+// listResp is the structure that represents the API response of the 'List' method, which contains route table list,
+// page details and the request information.
+type listResp struct {
+	// The list of the route tables.
+	RouteTables []RouteTable `json:"route_tables"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+	// The page information.
+	PageInfo pageInfo `json:"page_info"`
+}
+
+// pageInfo is the structure that represents the page information.
+type pageInfo struct {
+	// The next marker information.
+	NextMarker string `json:"next_marker"`
+	// The number of the route table in current page.
+	CurrentCount int `json:"current_count"`
+}
+
+// RouteTablePage represents the response pages of the List method.
+type RouteTablePage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no route table.
+func (r RouteTablePage) IsEmpty() (bool, error) {
+	resp, err := extractRouteTables(r)
+	return len(resp) == 0, err
+}
+
+// LastMarker returns the last marker index in a ListResult.
+func (r RouteTablePage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.NextMarker != "" {
+		return "", nil
+	}
+	return resp.NextMarker, nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s listResp
+	err := r.(RouteTablePage).Result.ExtractInto(&s)
+	return &s.PageInfo, err
+}
+
+// extractRouteTables is a method which to extract the response to a route table list.
+func extractRouteTables(r pagination.Page) ([]RouteTable, error) {
+	var s listResp
+	err := r.(RouteTablePage).Result.ExtractInto(&s)
+	return s.RouteTables, err
+}
+
+// updateResp is the structure that represents the API response of the 'Update' method, which contains route table
+// details and the request information.
+type updateResp struct {
+	// The response detail of the route table.
+	RouteTable RouteTable `json:"route_table"`
+	// The request ID.
+	RequestId string `json:"request_id"`
+}

--- a/openstack/er/v3/routetables/urls.go
+++ b/openstack/er/v3/routetables/urls.go
@@ -1,0 +1,11 @@
+package routetables
+
+import "github.com/chnsz/golangsdk"
+
+func rootURL(client *golangsdk.ServiceClient, instanceId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables")
+}
+
+func resourceURL(client *golangsdk.ServiceClient, instanceId, routeTableId string) string {
+	return client.ServiceURL("enterprise-router", instanceId, "route-tables", routeTableId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
In order to support the route table resource, four kinds of ER sdks are needed.
- route table
- route
- association
- propagation

The relationship of them are as follows:
```
- ER instance
  |- attachment
  |- route table
     |- route
     |- association
     |- propagation
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. support route table sdk.
2. support route sdk.
3. support association sdk.
4. support propagation sdk.
```
