### PR TITLE
feat(cce/turbo): support enable distributed CCE-Turbo cluster Management

### DIFF
--- a/openstack/cce/v3/clusters/results.go
+++ b/openstack/cce/v3/clusters/results.go
@@ -59,6 +59,8 @@ type Spec struct {
 	ContainerNetwork ContainerNetworkSpec `json:"containerNetwork" required:"true"`
 	//ENI network parameters
 	EniNetwork *EniNetworkSpec `json:"eniNetwork,omitempty"`
+	// Enable Distributed Cluster Management
+	EnableDistMgt bool `json:"enableDistMgt,omitempty"`
 	//Authentication parameters
 	Authentication AuthenticationSpec `json:"authentication,omitempty"`
 	// Charging mode of the cluster, which is 0 (on demand)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CCE Turbo supports the creation of distributed clusters, and it can manage remote clusters or nodes.
<img width="921" alt="截屏2023-04-24 15 32 48" src="https://user-images.githubusercontent.com/43004096/233929427-f0befddc-381e-4a55-a2e7-d50b856e522d.png">

And the v3 API of CCE has opened the creation parameter of this function: `"enableDistMgt"`
<img width="788" alt="截屏2023-04-24 15 37 12" src="https://user-images.githubusercontent.com/43004096/233930106-a526c705-fee7-4df1-935e-8415b7004873.png">

If we enable the parameter: `"enableDistMgt"`, we can create a distributed CCE Turbo cluster：
<img width="474" alt="截屏2023-04-24 15 40 04" src="https://user-images.githubusercontent.com/43004096/233930639-632c7138-8a55-43fa-a05f-17018685263a.png">


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
