### PR TITLE
feat(cce/turbo): support CCE Turbo partition management

### DIFF
--- a/openstack/cce/v3/nodes/results.go
+++ b/openstack/cce/v3/nodes/results.go
@@ -80,6 +80,8 @@ type Spec struct {
 	RunTime *RunTimeSpec `json:"runtime,omitempty"`
 	// taints to created nodes to configure anti-affinity
 	Taints []TaintSpec `json:"taints,omitempty"`
+	// The name of the created partition
+	Partition string `json:"partition,omitempty"`
 }
 
 // Gives the Nic spec of the node

--- a/openstack/cce/v3/partitions/doc.go
+++ b/openstack/cce/v3/partitions/doc.go
@@ -1,0 +1,9 @@
+// Package partitions is a new feature introduced by CCE Turbo remote distributed cluster management.
+// Currently, partitions are divided into three categories: Center, HomeZone, and IES.
+//   - Default: Indicates the availability zone resources of the HuaweiCloud data center
+//   - HomeZone: Indicates the edge computing area in the user's home, which is not currently supported
+//   - IES: IES is the edge station of HuaweiCloud, which deploys user-specific cloud resources to the
+//          local computer zone
+// The concept of partitions can support CCE Turbo to manage distributed nodes, which has
+// strong applicability in the field of edge computing.
+package partitions

--- a/openstack/cce/v3/partitions/requests.go
+++ b/openstack/cce/v3/partitions/requests.go
@@ -1,0 +1,176 @@
+package partitions
+
+import (
+	"reflect"
+
+	"github.com/chnsz/golangsdk"
+)
+
+var RequestOpts golangsdk.RequestOpts = golangsdk.RequestOpts{
+	MoreHeaders: map[string]string{"Content-Type": "application/json"},
+}
+
+// ListOpts allows the filtering of list data using given parameters.
+type ListOpts struct {
+	Name string `json:"name"`
+}
+
+// List returns collection of partitions.
+func List(client *golangsdk.ServiceClient, clusterID string, opts ListOpts) ([]Partitions, error) {
+	var r ListResult
+	_, r.Err = client.Get(rootURL(client, clusterID), &r.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+	})
+
+	allPartitions, err := r.ExtractPartitions()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return FilterPartitions(allPartitions, opts), nil
+}
+
+func FilterPartitions(partitions []Partitions, opts ListOpts) []Partitions {
+	var refinedPartitions []Partitions
+	var matched bool
+
+	m := map[string]FilterStruct{}
+
+	if opts.Name != "" {
+		m["Name"] = FilterStruct{Value: opts.Name, Driller: []string{"Metadata"}}
+	}
+
+	if len(m) > 0 && len(partitions) > 0 {
+		for _, partition := range partitions {
+			matched = true
+
+			for key, value := range m {
+				if sVal := GetStructNestedField(&partition, key, value.Driller); !(sVal == value.Value) {
+					matched = false
+				}
+			}
+			if matched {
+				refinedPartitions = append(refinedPartitions, partition)
+			}
+		}
+	} else {
+		refinedPartitions = partitions
+	}
+	return refinedPartitions
+}
+
+func GetStructNestedField(v *Partitions, field string, structDriller []string) string {
+	r := reflect.ValueOf(v)
+	for _, drillField := range structDriller {
+		f := reflect.Indirect(r).FieldByName(drillField).Interface()
+		r = reflect.ValueOf(f)
+	}
+	f1 := reflect.Indirect(r).FieldByName(field)
+	return string(f1.String())
+}
+
+type FilterStruct struct {
+	Value   string
+	Driller []string
+}
+
+// CreateOptsBuilder allows extensions to add additional parameters to the
+// Create request.
+type CreateOpts struct {
+	// API type, fixed value Partition
+	Kind string `json:"kind" required:"true"`
+	// API version, fixed value v3
+	ApiVersion string `json:"apiversion" required:"true"`
+	// Metadata required to create a Partition
+	Metadata CreateMetaData `json:"metadata"`
+	// specifications to create a Partition
+	Spec Spec `json:"spec" required:"true"`
+}
+
+// Metadata required to create a Partition
+type CreateMetaData struct {
+	// Partition name
+	Name string `json:"name,omitempty"`
+	// Partition tag, key value pair format
+	Labels map[string]string `json:"labels,omitempty"`
+	// Partition annotation, key value pair format
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new
+// logical Partition. When it is created, the Partition does not have an internal
+// interface
+type CreateOptsBuilder interface {
+	ToPartitionCreateMap() (map[string]interface{}, error)
+}
+
+// ToPartitionCreateMap builds a create request body from CreateOpts.
+func (opts CreateOpts) ToPartitionCreateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Create accepts a CreateOpts struct and uses the values to create a new
+// logical Partition.
+func Create(c *golangsdk.ServiceClient, clusterid string, opts CreateOptsBuilder) (r CreateResult) {
+	b, err := opts.ToPartitionCreateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	reqOpt := &golangsdk.RequestOpts{OkCodes: []int{201}}
+	_, r.Err = c.Post(rootURL(c, clusterid), b, &r.Body, reqOpt)
+	return
+}
+
+// Get retrieves a particular partitions based on its unique ID and cluster ID.
+func Get(c *golangsdk.ServiceClient, clusterid, partitionName string) (r GetResult) {
+	_, r.Err = c.Get(resourceURL(c, clusterid, partitionName), &r.Body, &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+	})
+	return
+}
+
+// UpdateOptsBuilder allows extensions to add additional parameters to the
+// Update request.
+type UpdateOptsBuilder interface {
+	ToPartitionUpdateMap() (map[string]interface{}, error)
+}
+
+// UpdateOpts contains all the values needed to update a new partition
+type UpdateOpts struct {
+	Metadata UpdateMetadata `json:"metadata,omitempty"`
+}
+
+type UpdateMetadata struct {
+	ContainerNetwork []ContainerNetwork `json:"containerNetwork,omitempty"`
+}
+
+// ToPartitionUpdateMap builds an update body based on UpdateOpts.
+func (opts UpdateOpts) ToPartitionUpdateMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "")
+}
+
+// Update allows partitions to be updated.
+func Update(c *golangsdk.ServiceClient, clusterid, partitionName string, opts UpdateOptsBuilder) (r UpdateResult) {
+	b, err := opts.ToPartitionUpdateMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = c.Put(resourceURL(c, clusterid, partitionName), b, &r.Body, &golangsdk.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}
+
+// Delete will permanently delete a particular partition based on its unique Name and cluster ID.
+func Delete(c *golangsdk.ServiceClient, clusterid, partitionName string) (r DeleteResult) {
+	_, r.Err = c.Delete(resourceURL(c, clusterid, partitionName), &golangsdk.RequestOpts{
+		OkCodes:     []int{200},
+		MoreHeaders: RequestOpts.MoreHeaders, JSONBody: nil,
+	})
+	return
+}

--- a/openstack/cce/v3/partitions/results.go
+++ b/openstack/cce/v3/partitions/results.go
@@ -1,0 +1,110 @@
+package partitions
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// Describes the Partition Structure of cluster
+type ListPartition struct {
+	// API type, fixed value "List"
+	Kind string `json:"kind"`
+	// API version, fixed value "v3"
+	Apiversion string `json:"apiVersion"`
+	// all Clusters
+	Partitions []Partitions `json:"items"`
+}
+
+// Individual partitions of the cluster
+type Partitions struct {
+	// API type, fixed value " Host "
+	Kind string `json:"kind"`
+	// API version, fixed value v3
+	Apiversion string `json:"apiVersion"`
+	// Partition metadata
+	Metadata Metadata `json:"metadata"`
+	// Partition detailed parameters
+	Spec Spec `json:"spec"`
+}
+
+// Metadata required to create a partition
+type Metadata struct {
+	// Partition name
+	Name string `json:"name"`
+}
+
+// Spec describes Partitions specification
+type Spec struct {
+	// The category of partition
+	Category string `json:"category,omitempty"`
+	// The availability zone name of the partition
+	PublicBorderGroup string `json:"publicBorderGroup,omitempty"`
+	// The default host network for the partition
+	HostNetwork HostNetwork `json:"hostNetwork,omitempty"`
+	// The default host network for the partition container
+	ContainerNetwork []ContainerNetwork `json:"containerNetwork,omitempty"`
+}
+
+// HostNetwork the default host network for the partition
+type HostNetwork struct {
+	// The default SubnetID for the partition
+	SubnetID string `json:"subnetID,omitempty"`
+}
+
+// ContainerNetwork the default host network for the partition container
+type ContainerNetwork struct {
+	// The default SubnetID for the partition container
+	SubnetID string `json:"subnetID,omitempty"`
+}
+
+type commonResult struct {
+	golangsdk.Result
+}
+
+// Extract is a function that accepts a result and extracts a partition.
+func (r commonResult) Extract() (*Partitions, error) {
+	var s Partitions
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+// ExtractPartitions is a function that accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func (r commonResult) ExtractPartitions() ([]Partitions, error) {
+	var s ListPartition
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Partitions, nil
+}
+
+// ListResult represents the result of a list operation. Call its ExtractCluster
+// method to interpret it as a Cluster.
+type ListResult struct {
+	commonResult
+}
+
+// CreateResult represents the result of a create operation. Call its Extract
+// method to interpret it as a Cluster.
+type CreateResult struct {
+	commonResult
+}
+
+// GetResult represents the result of a get operation. Call its Extract
+// method to interpret it as a Cluster.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation. Call its Extract
+// method to interpret it as a Cluster.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of a delete operation. Call its ExtractErr
+// method to determine if the request succeeded or failed.
+type DeleteResult struct {
+	golangsdk.ErrResult
+}

--- a/openstack/cce/v3/partitions/testing/doc.go
+++ b/openstack/cce/v3/partitions/testing/doc.go
@@ -1,0 +1,2 @@
+// partitions unit tests
+package testing

--- a/openstack/cce/v3/partitions/testing/fixture.go
+++ b/openstack/cce/v3/partitions/testing/fixture.go
@@ -1,0 +1,47 @@
+package testing
+
+import "github.com/chnsz/golangsdk/openstack/cce/v3/partitions"
+
+const Output = `{
+    "kind":"Partition",
+    "apiVersion":"v3",
+    "metadata":{
+        "name":"cn-south-1-ies-fstxz"
+    },
+    "spec":{
+        "hostNetwork":{
+            "subnetID":"d7131ed5-f813-4dbc-86f8-bcbdc07dce6f"
+        },
+        "containerNetwork":[
+            {
+                "subnetID":"b2f23c46-edaa-4e66-b82f-50edafa638f5"
+            },
+            {
+                "subnetID":"dee746d5-6c78-43fb-bc36-ac26c581a3ec"
+            }
+        ],
+        "publicBorderGroup":"cn-south-1-ies-fstxz",
+        "category":"IES"
+    }
+}`
+
+var Expected = &partitions.Partitions{
+	Kind:       "Partition",
+	Apiversion: "v3",
+	Metadata:   partitions.Metadata{Name: "cn-south-1-ies-fstxz"},
+	Spec: partitions.Spec{
+		Category:          "IES",
+		PublicBorderGroup: "cn-south-1-ies-fstxz",
+		HostNetwork: partitions.HostNetwork{
+			SubnetID: "d7131ed5-f813-4dbc-86f8-bcbdc07dce6f",
+		},
+		ContainerNetwork: []partitions.ContainerNetwork{
+			{
+				SubnetID: "b2f23c46-edaa-4e66-b82f-50edafa638f5",
+			},
+			{
+				SubnetID: "dee746d5-6c78-43fb-bc36-ac26c581a3ec",
+			},
+		},
+	},
+}

--- a/openstack/cce/v3/partitions/testing/requests_test.go
+++ b/openstack/cce/v3/partitions/testing/requests_test.go
@@ -1,0 +1,127 @@
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	fake "github.com/chnsz/golangsdk/openstack/cce/v3/common"
+	"github.com/chnsz/golangsdk/openstack/cce/v3/partitions"
+	th "github.com/chnsz/golangsdk/testhelper"
+)
+
+func TestListNode(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/api/v3/projects/c59fd21fd2a94963b822d8985b884673/clusters/cec124c2-58f1-11e8-ad73-0255ac101926/partitions", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprintf(w, `
+{
+    "kind":"List",
+    "apiVersion":"v3",
+    "items":[
+        {
+            "kind":"Partition",
+            "apiVersion":"v3",
+            "metadata":{
+                "name":"center",
+                "creationTimestamp":"2023-03-21 07:58:56.617633 +0000 UTC"
+            },
+            "spec":{
+                "hostNetwork":{
+                    "subnetID":"82f94fd8-a10a-4088-a514-3198b44fa1b6"
+                },
+                "containerNetwork":[
+                    {
+                        "subnetID":"86e5f9b8-53ec-4a58-a6f3-594b341f30e9"
+                    }
+                ],
+                "publicBorderGroup":"center",
+                "category":"Default"
+            }
+        },
+        {
+            "kind":"Partition",
+            "apiVersion":"v3",
+            "metadata":{
+                "name":"cn-south-1-ies-fstxz",
+                "creationTimestamp":"2023-03-21 12:12:10.269567 +0000 UTC"
+            },
+            "spec":{
+                "hostNetwork":{
+                    "subnetID":"d7131ed5-f813-4dbc-86f8-bcbdc07dce6f"
+                },
+                "containerNetwork":[
+                    {
+                        "subnetID":"b2f23c46-edaa-4e66-b82f-50edafa638f5"
+                    },
+                    {
+                        "subnetID":"dee746d5-6c78-43fb-bc36-ac26c581a3ec"
+                    }
+                ],
+                "publicBorderGroup":"cn-south-1-ies-fstxz",
+                "category":"IES"
+            }
+        }
+    ]
+}
+		`)
+	})
+
+	listPartitions := partitions.ListOpts{Name: "cn-south-1-ies-fstxz"}
+	actual, err := partitions.List(fake.ServiceClient(), "cec124c2-58f1-11e8-ad73-0255ac101926", listPartitions)
+
+	if err != nil {
+		t.Errorf("Failed to extract partitions: %v", err)
+	}
+
+	expected := []partitions.Partitions{
+		{
+			Kind:       "Partition",
+			Apiversion: "v3",
+			Metadata: partitions.Metadata{
+				Name: "cn-south-1-ies-fstxz",
+			},
+			Spec: partitions.Spec{
+				Category:          "IES",
+				PublicBorderGroup: "cn-south-1-ies-fstxz",
+				HostNetwork: partitions.HostNetwork{
+					SubnetID: "d7131ed5-f813-4dbc-86f8-bcbdc07dce6f",
+				},
+				ContainerNetwork: []partitions.ContainerNetwork{
+					{
+						SubnetID: "b2f23c46-edaa-4e66-b82f-50edafa638f5",
+					},
+					{
+						SubnetID: "dee746d5-6c78-43fb-bc36-ac26c581a3ec",
+					},
+				},
+			},
+		},
+	}
+
+	th.AssertDeepEquals(t, expected, actual)
+}
+
+func TestGetV3Partition(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	th.Mux.HandleFunc("/api/v3/projects/c59fd21fd2a94963b822d8985b884673/clusters/cec124c2-58f1-11e8-ad73-0255ac101926/partitions/cn-south-1-ies-fstxz", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, Output)
+	})
+
+	actual, err := partitions.Get(fake.ServiceClient(), "cec124c2-58f1-11e8-ad73-0255ac101926", "cn-south-1-ies-fstxz").Extract()
+	th.AssertNoErr(t, err)
+	expected := Expected
+	th.AssertDeepEquals(t, expected, actual)
+}

--- a/openstack/cce/v3/partitions/urls.go
+++ b/openstack/cce/v3/partitions/urls.go
@@ -1,0 +1,16 @@
+package partitions
+
+import "github.com/chnsz/golangsdk"
+
+const (
+	rootPath     = "clusters"
+	resourcePath = "partitions"
+)
+
+func rootURL(c *golangsdk.ServiceClient, clusterid string) string {
+	return c.ServiceURL(rootPath, clusterid, resourcePath)
+}
+
+func resourceURL(c *golangsdk.ServiceClient, clusterid, partitionName string) string {
+	return c.ServiceURL(rootPath, clusterid, resourcePath, partitionName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Related to PR: https://github.com/huaweicloud/terraform-provider-huaweicloud/pull/2956

The partitions is a new feature introduced by CCE Turbo remote distributed cluster management. Currently, partitions are divided into three categories: Center, HomeZone, and IES.
   - `Default`: Indicates the availability zone resources of the HuaweiCloud data center.
   - `HomeZone`: Indicates the edge computing area in the user's home, which is not currently supported.
   - `IES`: IES is the edge station of HuaweiCloud, which deploys user-specific cloud resources to the local computer zone.
The concept of partitions can support CCE Turbo to manage distributed nodes, which has strong applicability in the field of edge computing.

1. When we create a CCE Turbo and enable the CCE distributed management function (CCE Remote feature), then we can see the `partition management` in the CCE console
<img width="1920" alt="截屏2023-04-26 18 02 39" src="https://user-images.githubusercontent.com/43004096/234542674-2c76ba87-84c9-4412-8d6e-79034348c8d9.png">

2. Using partition management, we can create an IES availability zone located in the edge zone, which is a CCE remote zone
<img width="1918" alt="截屏2023-04-26 18 04 20" src="https://user-images.githubusercontent.com/43004096/234543084-0b632aa1-62c1-4458-a395-cae646806830.png">

3. When purchasing a CCE node, we can also choose resources in the IES availability zone and create it as a CCE working node
<img width="1871" alt="截屏2023-04-26 18 06 05" src="https://user-images.githubusercontent.com/43004096/234543388-5ff46a4e-a504-4cd2-baa6-870a185dc1c2.png">

Example:
```
Create vpc, subnet resource...

resource "huaweicloud_cce_cluster" "cce_test" {
  name                         = "cce-test"
  flavor_id                    = "cce.s2.medium"
  cluster_version              = "v1.23"
  vpc_id                       = huaweicloud_vpc.vpc_ldm.id
  subnet_id                    = huaweicloud_vpc_subnet.subnet_center.id
  container_network_type       = "eni" // 云原生容器网络2.0
  eni_subnet_id                = huaweicloud_vpc_subnet.subnet_center.ipv4_subnet_id
  eni_subnet_cidr              = huaweicloud_vpc_subnet.subnet_center.cidr
  enable_distribute_management = true
}

resource "huaweicloud_cce_partition" "edge_part" {
  cluster_id           = huaweicloud_cce_cluster.cce_test.id
  category             = "IES"
  availability_zone    = var.ies_zone
  partition_subnet_id  = huaweicloud_vpc_subnet.subnet_edge.id
  container_subnet_ids = [huaweicloud_vpc_subnet.subnet_edge.ipv4_subnet_id]
}

resource "huaweicloud_cce_node" "cce_ies_node" {
  count = 2

  cluster_id        = huaweicloud_cce_cluster.cce_test.id
  name              = "cce-ies-node-${count.index}"
  availability_zone = var.az_ies
  partition         = huaweicloud_cce_partition.edge_part.availability_zone    
  flavor_id         = var.ccenode_ies_flavor
  os                = "EulerOS 2.9"
  runtime           = "docker"
  password          = "******"

  root_volume {
    size       = 50
    volumetype = "SSD"
  }
  data_volumes {
    size       = 100
    volumetype = "SSD"
  }
}
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
