### PR TITLE
fix(modelarts/notebook): fix the next page calculation of URL

### DIFF
--- a/openstack/modelarts/v1/notebook/results.go
+++ b/openstack/modelarts/v1/notebook/results.go
@@ -1,6 +1,10 @@
 package notebook
 
-import "github.com/chnsz/golangsdk/pagination"
+import (
+	"strconv"
+
+	"github.com/chnsz/golangsdk/pagination"
+)
 
 const (
 	StatusInit         = "INIT"
@@ -110,16 +114,46 @@ type ImagePage struct {
 	pagination.OffsetPageBase
 }
 
-// IsEmpty checks whether a RouteTablePage struct is empty.
-func (b ImagePage) IsEmpty() (bool, error) {
-	arr, err := ExtractImages(b)
-	return len(arr) == 0, err
+// IsEmpty checks whether a ImagePage struct is empty.
+func (current ImagePage) IsEmpty() (bool, error) {
+	resp, err := extractImagesResp(current)
+	if err != nil {
+		return false, err
+	}
+	return len(resp.Data) == 0, nil
+}
+
+func extractImagesResp(r pagination.Page) (ImagesResp, error) {
+	var s ImagesResp
+	err := (r.(ImagePage)).ExtractInto(&s)
+	return s, err
 }
 
 func ExtractImages(r pagination.Page) ([]ImageDetail, error) {
 	var s ImagesResp
 	err := (r.(ImagePage)).ExtractInto(&s)
 	return s.Data, err
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (current ImagePage) NextPageURL() (string, error) {
+	next := current.NextOffset()
+	if next == 0 {
+		return "", nil
+	}
+	resp, _ := extractImagesResp(current)
+	currentURL := current.URL
+	q := currentURL.Query()
+
+	if resp.Current+1 < resp.Pages {
+		q.Set("offset", strconv.Itoa(next))
+	} else {
+		// This page is not the last page.
+		return "", nil
+	}
+
+	currentURL.RawQuery = q.Encode()
+	return currentURL.String(), nil
 }
 
 type flavorResp struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The offset query parameter is a parameter used to calculate the page number, not the real offset. Therefore, the traditional offset calculation is no longer applicable to the notebook images of the ModelArts service.
- In traditional offset calculation, the offset of next page URL is `offset + limit`, and the query result is as follow:

(Assuming that the total number of images is 33, the limit adopts the default value)
```
The first querying result: limit=200, offset=0
{
  current: 0,
  data: [...], // the length of data array is 33.
  pages: 1,
  size: 200, // the maximum number for a page.
  total: 33
}
The second querying result: limit=200, offset=233
{
"error_code": "ModelArts.6400",
"error_msg": "fromIndex(200) \u003e toIndex(33)"
}
```
- In new offset calculation, the offset of next page URL is `offset + limit` (not first page), `length of data array` (limit value is not set and the page is first page) and `total number` (the page is last page), and the query result is as follow:

(Assuming that the total number of images is 33, the limit adopts the default value)
```
The first querying result: limit=200, offset=0
{
  current: 0,
  data: [...], // the length of data array is 33.
  pages: 1,
  size: 200, // the maximum number for a page.
  total: 33
}
This page is the last page, the next url is empty string.
```
(Assuming that the total number of images is 33, the limit is 30)
```
The first querying result: limit=30, offset=0
{
  current: 0,
  data: [...], // the length of data array is 30.
  pages: 2,
  size: 30, // the maximum number for a page.
  total: 33
}
The second querying result: limit=30, offset=30
{
  current: 1,
  data: [...], // the length of data array is 3.
  pages: 2,
  size: 30, // the maximum number for a page.
  total: 33
}
This page is the last page, the next url is empty string.
```
(Assuming that the total number of images is 33, the limit is 33)
```
The first querying result: limit=33, offset=33
{
  current: 1,
  data: [], // the length of data array is 0.
  pages: 1,
  size: 33, // the maximum number for a page.
  total: 33
}
This page is the last page, the next url is empty string.
```
Only values of limit and offset are both equals total number, the API response is return empty array.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. fix the next page calculation of url.
```
