### PR TITLE
feat(MRS): add vpc_id to CreateOps

### DIFF
--- a/openstack/mrs/v2/clusters/requests.go
+++ b/openstack/mrs/v2/clusters/requests.go
@@ -33,6 +33,7 @@ type CreateOpts struct {
 	// Click Virtual Private Cloud and select Virtual Private Cloud from the left list.
 	// On the Virtual Private Cloud page, obtain the VPC name from the list.
 	VpcName string `json:"vpc_name" required:"true"`
+	VpcId   string `json:"vpc_id,omitempty"`
 	// List of component names, which are separated by commas (,). The options are as follows:
 	// MRS 3.0.5
 	//   ANALYSIS: Hadoop,Spark2x,HBase,Hive,Hue,Loader,Flink,Oozie,ZooKeeper,Ranger,Tez,Impala,Presto,Kudu,Alluxio
@@ -126,8 +127,6 @@ type CreateOpts struct {
 }
 
 type ExternalDatasource struct {
-	// Data connection association ID
-	MapId         string `json:"map_id,omitempty"`
 	ConnectorId   string `json:"connector_id,omitempty"`
 	ComponentName string `json:"component_name,omitempty"`
 	/**
@@ -146,10 +145,6 @@ type ExternalDatasource struct {
 		gaussdb-mysql: GaussDB(for MySQL)
 	**/
 	SourceType string `json:"source_type,omitempty"`
-	// ID of the associated cluster
-	ClusterId string `json:"cluster_id,omitempty"`
-	// Data connection status. The options are as follows: 0: normal; 1: in use
-	Status string `json:"status,omitempty"`
 }
 
 // ChargeInfo is a structure representing billing information.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
1. Add vpc_id to CreateOps. There is a bug in this API, when adding an external data source, vpc_id is required.
2. Remove useless parameters from ExternalDatasource struct


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
