### PR TITLE
feat: support to query DNS nameservers

### DIFF
--- a/openstack/dns/v2/nameservers/requests.go
+++ b/openstack/dns/v2/nameservers/requests.go
@@ -1,0 +1,40 @@
+package nameservers
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+type ListOpts struct {
+	// Type of the name server. Value options:
+	// public: indicates a public name server.
+	// private: indicates a private name server.
+	// It is left blank by default.
+	Type string `q:"type"`
+	// Region ID. When you query a public name server, leave this parameter blank.
+	// Exact matching will work. It is left blank by default.
+	Region string `q:"region"`
+}
+
+// ToNameServersQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToNameServersQuery() (string, error) {
+	q, err := golangsdk.BuildQueryString(opts)
+	return q.String(), err
+}
+
+// List implements a nameserver List request.
+func List(client *golangsdk.ServiceClient, opts *ListOpts) ([]NameServer, error) {
+	url := baseURL(client)
+	if opts != nil {
+		query, err := opts.ToNameServersQuery()
+		if err != nil {
+			return nil, err
+		}
+		url += query
+	}
+
+	var s struct {
+		NameServers []NameServer `json:"nameservers"`
+	}
+	_, err := client.Get(url, &s, nil)
+	return s.NameServers, err
+}

--- a/openstack/dns/v2/nameservers/results.go
+++ b/openstack/dns/v2/nameservers/results.go
@@ -1,0 +1,24 @@
+package nameservers
+
+// Zone represents a DNS zone.
+type NameServer struct {
+	// Type of the name server.Value options:
+	// public: indicates a public name server.
+	// private: indicates a private name server.
+	Type string `json:"type"`
+
+	// Region ID. When you query a public name server, leave this parameter blank.
+	Region string `json:"region"`
+
+	// Array of name server record objects
+	Records []Record `json:"ns_records"`
+}
+
+type Record struct {
+	// Host name. This parameter is left blank when a private name server is used.
+	HostName string `json:"hostname"`
+	// Address of the name server. When the server is a public name server, this parameter is left blank.
+	Address string `json:"address"`
+	// the priority. If the value of priority is 1, the DNS server is the first one to resolve domain names.
+	Priority int `json:"priority"`
+}

--- a/openstack/dns/v2/nameservers/urls.go
+++ b/openstack/dns/v2/nameservers/urls.go
@@ -1,0 +1,7 @@
+package nameservers
+
+import "github.com/chnsz/golangsdk"
+
+func baseURL(c *golangsdk.ServiceClient) string {
+	return c.ServiceURL("nameservers")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
the API URL: https://support.huaweicloud.com/intl/en-us/api-dns/dns_api_69001.html

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
