### PR TITLE
feat: WAF policy add new fields

### DIFF
--- a/openstack/waf_hw/v1/policies/requests.go
+++ b/openstack/waf_hw/v1/policies/requests.go
@@ -53,11 +53,12 @@ type UpdateOptsBuilder interface {
 
 // UpdateOpts contains all the values needed to update a policy.
 type UpdateOpts struct {
-	Name                string        `json:"name,omitempty"`
+	FullDetection       *bool         `json:"full_detection,omitempty"`
+	RobotAction         *Action       `json:"robot_action,omitempty"`
 	Action              *Action       `json:"action,omitempty"`
 	Options             *PolicyOption `json:"options,omitempty"`
+	Name                string        `json:"name,omitempty"`
 	Level               int           `json:"level,omitempty"`
-	FullDetection       *bool         `json:"full_detection,omitempty"`
 	EnterpriseProjectId string        `q:"enterprise_project_id" json:"-"`
 }
 

--- a/openstack/waf_hw/v1/policies/results.go
+++ b/openstack/waf_hw/v1/policies/results.go
@@ -6,13 +6,16 @@ import (
 
 // Policy contains the infomateion of the policy.
 type Policy struct {
-	Id            string       `json:"id"`
-	Name          string       `json:"name"`
-	Action        Action       `json:"action"`
-	Options       PolicyOption `json:"options"`
-	Level         int          `json:"level"`
-	FullDetection bool         `json:"full_detection"`
-	BindHosts     []BindHost   `json:"bind_host"`
+	Id            string            `json:"id"`
+	Name          string            `json:"name"`
+	Action        Action            `json:"action"`
+	RobotAction   Action            `json:"robot_action"`
+	Options       PolicyOption      `json:"options"`
+	Level         int               `json:"level"`
+	FullDetection bool              `json:"full_detection"`
+	Hosts         []string          `json:"hosts"`
+	BindHosts     []BindHost        `json:"bind_host"`
+	Extend        map[string]string `json:"extend"`
 }
 
 //Action contains actions after the attack is detected
@@ -23,28 +26,33 @@ type Action struct {
 
 // PolicyOption contains the protection rule of a policy
 type PolicyOption struct {
-	Webattack      bool `json:"webattack,omitempty"`
-	Common         bool `json:"common,omitempty"`
-	Crawler        bool `json:"crawler,omitempty"`
-	CrawlerEngine  bool `json:"crawler_engine,omitempty"`
-	CrawlerScanner bool `json:"crawler_scanner,omitempty"`
-	CrawlerScript  bool `json:"crawler_script,omitempty"`
-	CrawlerOther   bool `json:"crawler_other,omitempty"`
-	Webshell       bool `json:"webshell,omitempty"`
-	Cc             bool `json:"cc,omitempty"`
-	Custom         bool `json:"custom,omitempty"`
-	Whiteblackip   bool `json:"whiteblackip,omitempty"`
-	Ignore         bool `json:"ignore,omitempty"`
-	Privacy        bool `json:"privacy,omitempty"`
-	Antitamper     bool `json:"antitamper,omitempty"`
+	Webattack      *bool `json:"webattack,omitempty"`
+	Common         *bool `json:"common,omitempty"`
+	Crawler        *bool `json:"crawler,omitempty"`
+	CrawlerEngine  *bool `json:"crawler_engine,omitempty"`
+	CrawlerScanner *bool `json:"crawler_scanner,omitempty"`
+	CrawlerScript  *bool `json:"crawler_script,omitempty"`
+	CrawlerOther   *bool `json:"crawler_other,omitempty"`
+	Webshell       *bool `json:"webshell,omitempty"`
+	Cc             *bool `json:"cc,omitempty"`
+	Custom         *bool `json:"custom,omitempty"`
+	Whiteblackip   *bool `json:"whiteblackip,omitempty"`
+	Ignore         *bool `json:"ignore,omitempty"`
+	Privacy        *bool `json:"privacy,omitempty"`
+	Antitamper     *bool `json:"antitamper,omitempty"`
+	GeoIP          *bool `json:"geoip,omitempty"`
+	Antileakage    *bool `json:"antileakage,omitempty"`
+	BotEnable      *bool `json:"bot_enable,omitempty"`
+	FollowedAction *bool `json:"followed_action,omitempty"`
+	Anticrawler    *bool `json:"anticrawler,omitempty"`
 }
 
 // BindHost the hosts bound to this policy.
 type BindHost struct {
-	Id       string `json:"id,omitempty"`
-	Hostname string `json:"hostname,omitempty"`
-	WafType  string `json:"waf_type,omitempty"`
-	Mode     string `json:"mode,omitempty"`
+	Id       string `json:"id"`
+	Hostname string `json:"hostname"`
+	WafType  string `json:"waf_type"`
+	Mode     string `json:"mode"`
 }
 
 type commonResult struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Policy add new fields: robot_action, bind_hosts, deep_inspection, header_inspection, shiro_decryption_check, options.geolocation_access_control, options.information_leakage_prevention, options.bot_enable, options.known_attack_source, options.anti_crawler
- Make options fields Optional.
- Remove BindHost omitempty mark。
- The update parameters is use less: modulex_options, hosts, bind_host, extend

API URL： https://support.huaweicloud.com/api-waf/UpdatePolicy.html
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
