### PR TITLE
feat(cbr/vault): consistent level can be updated

### DIFF
--- a/openstack/cbr/v3/vaults/requests.go
+++ b/openstack/cbr/v3/vaults/requests.go
@@ -106,6 +106,12 @@ type UpdateOpts struct {
 }
 
 type BillingUpdate struct {
+	// Vault specifications
+	// The valid values are as follows:
+	// + app_consistent
+	// + crash_consistent
+	ConsistentLevel string `json:"consistent_level,omitempty"`
+	// Vault size, in GB.
 	Size int `json:"size,omitempty"`
 }
 
@@ -155,8 +161,8 @@ type ListOptsBuilder interface {
 	ToPolicyListQuery() (string, error)
 }
 
-//List is a method to obtain the specified CBR vaults according to the vault ID, vault name and so on.
-//This method can also obtain all the CBR vaults through the default parameter settings.
+// List is a method to obtain the specified CBR vaults according to the vault ID, vault name and so on.
+// This method can also obtain all the CBR vaults through the default parameter settings.
 func List(client *golangsdk.ServiceClient, opts ListOptsBuilder) pagination.Pager {
 	url := rootURL(client)
 	if opts != nil {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The consistent level can be updated.
But only `crash_consistent` can be udpated to `app_consistent`, the `app_consistent` cannot be udpated to `crash_consistent`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. add consistent level to the 'BillingUpdate' structure.
```
