### PR TITLE
fix(WAF): fix WAF dedicated domain struct fields

### DIFF
--- a/openstack/waf_hw/v1/premium_domains/requests.go
+++ b/openstack/waf_hw/v1/premium_domains/requests.go
@@ -15,13 +15,28 @@ var RequestOpts = golangsdk.RequestOpts{
 
 // CreatePremiumHostOpts the options for creating premium domains.
 type CreateOpts struct {
-	CertificateId       string   `json:"certificateid,omitempty"`
-	CertificateName     string   `json:"certificatename,omitempty"`
-	HostName            string   `json:"hostname" required:"true"`
-	Proxy               *bool    `json:"proxy,omitempty"`
-	PolicyId            string   `json:"policyid,omitempty"`
-	Servers             []Server `json:"server,omitempty"`
-	EnterpriseProjectID string   `q:"enterprise_project_id" json:"-"`
+	CertificateId       string            `json:"certificateid,omitempty"`
+	CertificateName     string            `json:"certificatename,omitempty"`
+	HostName            string            `json:"hostname" required:"true"`
+	Proxy               *bool             `json:"proxy,omitempty"`
+	PolicyId            string            `json:"policyid,omitempty"`
+	Servers             []Server          `json:"server,omitempty"`
+	BlockPage           *BlockPage        `json:"block_page,omitempty"`
+	ForwardHeaderMap    map[string]string `json:"forward_header_map,omitempty"`
+	Description         string            `json:"description,omitempty"`
+	EnterpriseProjectID string            `q:"enterprise_project_id" json:"-"`
+}
+
+type BlockPage struct {
+	Template    string      `json:"template,omitempty"`
+	CustomPage  *CustomPage `json:"custom_page,omitempty"`
+	RedirectUrl string      `json:"redirect_url,omitempty"`
+}
+
+type CustomPage struct {
+	StatusCode  string `json:"status_code,omitempty"`
+	ContentType string `json:"content_type,omitempty"`
+	Content     string `json:"content,omitempty"`
 }
 
 // PremiumDomainServer the options of domain server for creating premium domains.
@@ -109,13 +124,42 @@ func List(c *golangsdk.ServiceClient, opts ListPremiumHostOpts) (*PremiumHostLis
 
 // UpdatePremiumHostOpts the options for updating premium domains.
 type UpdatePremiumHostOpts struct {
-	Proxy               *bool  `json:"proxy,omitempty"`
-	CertificateId       string `json:"certificateid,omitempty"`
-	CertificateName     string `json:"certificatename,omitempty"`
-	Tls                 string `json:"tls,omitempty"`
-	Cipher              string `json:"cipher,omitempty"`
-	Flag                *Flag  `json:"flag,omitempty"`
-	EnterpriseProjectID string `q:"enterprise_project_id" json:"-"`
+	Proxy               *bool             `json:"proxy,omitempty"`
+	CertificateId       string            `json:"certificateid,omitempty"`
+	CertificateName     string            `json:"certificatename,omitempty"`
+	Tls                 string            `json:"tls,omitempty"`
+	Cipher              string            `json:"cipher,omitempty"`
+	Description         *string           `json:"description,omitempty"`
+	WebTag              *string           `json:"web_tag,omitempty"`
+	BlockPage           *BlockPage        `json:"block_page,omitempty"`
+	TrafficMark         *TrafficMark      `json:"traffic_mark,omitempty"`
+	CircuitBreaker      *CircuitBreaker   `json:"circuit_breaker,omitempty"`
+	TimeoutConfig       *TimeoutConfig    `json:"timeout_config,omitempty"`
+	Flag                *Flag             `json:"flag,omitempty"`
+	ForwardHeaderMap    map[string]string `json:"forward_header_map,omitempty"`
+	EnterpriseProjectID string            `q:"enterprise_project_id" json:"-"`
+}
+
+type TrafficMark struct {
+	Sip    []string `json:"sip,omitempty"`
+	Cookie string   `json:"cookie,omitempty"`
+	Params string   `json:"params,omitempty"`
+}
+
+type CircuitBreaker struct {
+	Switch           *bool    `json:"switch,omitempty"`
+	DeadNum          *int     `json:"dead_num,omitempty"`
+	DeadRatio        *float64 `json:"dead_ratio,omitempty"`
+	BlockTime        *int     `json:"block_time,omitempty"`
+	SuperpositionNum *int     `json:"superposition_num,omitempty"`
+	SuspendNum       *int     `json:"suspend_num,omitempty"`
+	SusBlockTime     *int     `json:"sus_block_time,omitempty"`
+}
+
+type TimeoutConfig struct {
+	ConnectTimeout *int `json:"connect_timeout,omitempty"`
+	SendTimeout    *int `json:"send_timeout,omitempty"`
+	ReadTimeout    *int `json:"read_timeout,omitempty"`
 }
 
 type Flag struct {

--- a/openstack/waf_hw/v1/premium_domains/results.go
+++ b/openstack/waf_hw/v1/premium_domains/results.go
@@ -14,29 +14,40 @@ type CreatePremiumHostRst struct {
 }
 
 type PremiumHost struct {
-	Id              string            `json:"id"`
-	PolicyId        string            `json:"policyid"`
-	HostName        string            `json:"hostname"`
-	DomainId        string            `json:"domainid"`
-	ProjectId       string            `json:"project_id"`
-	AccessCode      string            `json:"access_code"`
-	Protocol        string            `json:"protocol"`
-	Servers         []Server          `json:"server"`
-	CertificateId   string            `json:"certificateid"`
-	CertificateName string            `json:"certificatename"`
-	Tls             string            `json:"tls"`
-	Cipher          string            `json:"cipher"`
-	Proxy           bool              `json:"proxy"`
-	Locked          int               `json:"locked"`
-	ProtectStatus   int               `json:"protect_status"`
-	AccessStatus    int               `json:"access_status"`
-	Timestamp       int64             `json:"timestamp"`
-	BlockPage       DomainBlockPage   `json:"block_page"`
-	Extend          map[string]string `json:"extend"`
-	TrafficMark     DomainTrafficMark `json:"traffic_mark"`
-	Flag            map[string]string `json:"flag"`
-	Mode            string            `json:"mode"`
-	PoolIds         []string          `json:"pool_ids"`
+	Id                  string               `json:"id"`
+	HostName            string               `json:"hostname"`
+	Protocol            string               `json:"protocol"`
+	Servers             []Server             `json:"server"`
+	Proxy               bool                 `json:"proxy"`
+	Locked              int                  `json:"locked"`
+	Timestamp           int64                `json:"timestamp"`
+	Tls                 string               `json:"tls"`
+	Cipher              string               `json:"cipher"`
+	Extend              map[string]string    `json:"extend"`
+	Flag                map[string]string    `json:"flag"`
+	Description         string               `json:"description"`
+	PolicyId            string               `json:"policyid"`
+	DomainId            string               `json:"domainid"`
+	ProjectId           string               `json:"projectid"`
+	EnterpriseProjectId string               `json:"enterprise_project_id"`
+	CertificateId       string               `json:"certificateid"`
+	CertificateName     string               `json:"certificatename"`
+	ProtectStatus       int                  `json:"protect_status"`
+	AccessStatus        int                  `json:"access_status"`
+	WebTag              string               `json:"web_tag"`
+	BlockPage           DomainBlockPage      `json:"block_page"`
+	TrafficMark         DomainTrafficMark    `json:"traffic_mark"`
+	CircuitBreaker      DomainCircuitBreaker `json:"circuit_breaker"`
+	TimeoutConfig       DomainTimeoutConfig  `json:"timeout_config"`
+	ForwardHeaderMap    map[string]string    `json:"forward_header_map"`
+	AccessProgress      []AccessProgress     `json:"access_progress"`
+
+	// Deprecated
+	AccessCode string `json:"access_code"`
+	// Deprecated
+	Mode string `json:"mode"`
+	// Deprecated
+	PoolIds []string `json:"pool_ids"`
 }
 
 type SimplePremiumHost struct {
@@ -66,6 +77,27 @@ type DomainTrafficMark struct {
 	Sip    []string `json:"sip"`
 	Cookie string   `json:"cookie"`
 	Params string   `json:"params"`
+}
+
+type DomainCircuitBreaker struct {
+	Switch           bool    `json:"switch"`
+	DeadNum          int     `json:"dead_num"`
+	DeadRatio        float64 `json:"dead_ratio"`
+	BlockTime        int     `json:"block_time"`
+	SuperpositionNum int     `json:"superposition_num"`
+	SuspendNum       int     `json:"suspend_num"`
+	SusBlockTime     int     `json:"sus_block_time"`
+}
+
+type DomainTimeoutConfig struct {
+	ConnectTimeout int `json:"connect_timeout"`
+	SendTimeout    int `json:"send_timeout"`
+	ReadTimeout    int `json:"read_timeout"`
+}
+
+type AccessProgress struct {
+	Step   int `json:"step"`
+	Status int `json:"status"`
 }
 
 type PremiumHostList struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

fix WAF dedicated domain struct fields

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

- The API link refer to: https://support.huaweicloud.com/api-waf/CreatePremiumHost.html
- For update request body, `locked`, `protect_status`, `access_status`, `timestamp`, `pool_ids` is useless. And `web_tag` is not stated in the documentation, but it is actually available.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
