### PR TITLE
feat(cbr/backup): Support new method to update backup share status

### DIFF
--- a/openstack/cbr/v3/members/requests.go
+++ b/openstack/cbr/v3/members/requests.go
@@ -81,6 +81,42 @@ func List(client *golangsdk.ServiceClient, opts ListOpts) ([]Member, error) {
 	return ExtractMembers(pages)
 }
 
+// UpdateOpts is the structure that used to modify the shared member status.
+type UpdateOpts struct {
+	// Backup ID.
+	BackupId string `json:"-" required:"true"`
+	// Member ID.
+	MemberId string `json:"-" required:"true"`
+	// Status of a shared backup
+	// The valid values are as follows:
+	// + accepted
+	// + pending
+	// + rejected
+	Status string `json:"status" required:"true"`
+	// Vault in which the shared backup is to be stored.
+	// Only UUID is supported.
+	// When updating the status of a backup sharing member:
+	// + If the backup is accepted, vault_id must be specified.
+	// + If the backup is rejected, vault_id is not required.
+	VaultId string `json:"vault_id,omitempty"`
+}
+
+// Update is a method used to modify the specified shared member using given parameters.
+func Update(client *golangsdk.ServiceClient, opts UpdateOpts) (*Member, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r struct {
+		Member Member `json:"member"`
+	}
+	_, err = client.Put(resourceURL(client, opts.BackupId, opts.MemberId), b, &r, &golangsdk.RequestOpts{
+		MoreHeaders: requestOpts.MoreHeaders,
+	})
+	return &r.Member, err
+}
+
 // Delete is a method to remove a specified member from the specified backup.
 func Delete(client *golangsdk.ServiceClient, backupId, memberId string) error {
 	_, err := client.Delete(resourceURL(client, backupId, memberId), &golangsdk.RequestOpts{


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new method to update backup share status

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. support a new method to update the shared member or shared backup status.
```
