### PR TITLE
chore(fgs/function): support a new param: depend_version_list

### DIFF
--- a/openstack/fgs/v2/function/results.go
+++ b/openstack/fgs/v2/function/results.go
@@ -39,7 +39,8 @@ type Function struct {
 	FuncVpc             FuncVpc        `json:"func_vpc"`
 	MountConfig         MountConfig    `json:"mount_config,omitempty"`
 	Concurrency         int            `json:"-"`
-	DependList          []string       `json:"depend_list"`
+	DependList          []string       `json:"depend_list"` // Deprecated
+	DependVersionList   []string       `json:"depend_version_list"`
 	StrategyConfig      StrategyConfig `json:"strategy_config"`
 	ExtendConfig        string         `json:"extend_config"`
 	Dependencies        []*Dependency  `json:"dependencies"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameter `depend_list` has been deprecated and the parameter `depend_version_list` is used instead.
Currently, all new dependency packages are dependency packages with versions. 
- However, old dependency packages without versions will be automatically processed as dependency packages with versions by the service. This problem occurs only when they are used for the first time.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. Mark the parameter `depend_list` with the `deprecated` comment.
2. Support a new parameter `depend_version_list`.
```
