### PR TITLE
chore(eip): add params for resource vpc bandwidth

### DIFF
--- a/openstack/networking/v1/bandwidths/results.go
+++ b/openstack/networking/v1/bandwidths/results.go
@@ -4,15 +4,16 @@ import (
 	"github.com/chnsz/golangsdk"
 )
 
-//BandWidth is a struct that represents a bandwidth
+// BandWidth is a struct that represents a bandwidth
 type BandWidth struct {
-	ID            string `json:"id"`
-	Name          string `json:"name"`
-	Size          int    `json:"size"`
-	ShareType     string `json:"share_type"`
-	TenantID      string `json:"tenant_id"`
-	BandwidthType string `json:"bandwidth_type"`
-	ChargeMode    string `json:"charge_mode"`
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Size              int    `json:"size"`
+	ShareType         string `json:"share_type"`
+	TenantID          string `json:"tenant_id"`
+	BandwidthType     string `json:"bandwidth_type"`
+	PublicBorderGroup string `json:"public_border_group"`
+	ChargeMode        string `json:"charge_mode"`
 
 	PublicipInfo []PublicIpinfo `json:"publicip_info"`
 
@@ -44,7 +45,7 @@ type PublicIpinfo struct {
 	PublicipType string `json:"publicip_type"`
 }
 
-//GetResult is a return struct of get method
+// GetResult is a return struct of get method
 type GetResult struct {
 	golangsdk.Result
 }
@@ -57,7 +58,7 @@ func (r GetResult) Extract() (BandWidth, error) {
 	return BW.BW, err
 }
 
-//UpdateResult is a struct which contains the result of update method
+// UpdateResult is a struct which contains the result of update method
 type UpdateResult struct {
 	golangsdk.Result
 }
@@ -68,7 +69,7 @@ func (r UpdateResult) Extract() (BandWidth, error) {
 	return bw, err
 }
 
-//ListResult is a struct which contains the result of list method
+// ListResult is a struct which contains the result of list method
 type ListResult struct {
 	golangsdk.Result
 }

--- a/openstack/networking/v2/bandwidths/requests.go
+++ b/openstack/networking/v2/bandwidths/requests.go
@@ -30,6 +30,8 @@ type CreateOpts struct {
 	Size                *int   `json:"size" required:"true"`
 	ChargeMode          string `json:"charge_mode,omitempty"`
 	EnterpriseProjectId string `json:"enterprise_project_id,omitempty"`
+	PublicBorderGroup   string `json:"public_border_group,omitempty"`
+	BandwidthType       string `json:"bandwidth_type,omitempty"`
 }
 
 func (opts CreateOpts) ToBandWidthCreateMap() (map[string]interface{}, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Add params `bandwidth_type` and `public_border_group` for resource `huaweicloud_vpc_bandwidth`.