### PR TITLE
feat(BMS): bms instance support manage server status

### DIFF
--- a/openstack/bms/v1/baremetalservers/requests.go
+++ b/openstack/bms/v1/baremetalservers/requests.go
@@ -194,6 +194,50 @@ type AddNicsOptsBuilder interface {
 	ToServerAddNicsMap() (map[string]interface{}, error)
 }
 
+func (opts StopServerOps) ToServerStopServerMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "os-stop")
+}
+
+func (opts StartServerOps) ToServerStartServerMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "os-start")
+}
+
+func (opts RebootServerOps) ToServerRebootServerMap() (map[string]interface{}, error) {
+	return golangsdk.BuildRequestBody(opts, "reboot")
+}
+
+type StartServerOps struct {
+	Servers []Servers `json:"servers" required:"true"`
+}
+
+type StopServerOps struct {
+	// The value can be: HARD and SOFT. Only HARD takes effect.
+	Type    string    `json:"type" required:"true"`
+	Servers []Servers `json:"servers" required:"true"`
+}
+
+type RebootServerOps struct {
+	// The value can be: HARD and SOFT. Only HARD takes effect.
+	Type    string    `json:"type" required:"true"`
+	Servers []Servers `json:"servers" required:"true"`
+}
+
+type Servers struct {
+	ID string `json:"id" required:"true"`
+}
+
+type RebootServerOpsBuilder interface {
+	ToServerRebootServerMap() (map[string]interface{}, error)
+}
+
+type StartServerOpsBuilder interface {
+	ToServerStartServerMap() (map[string]interface{}, error)
+}
+
+type StopServerOpsBuilder interface {
+	ToServerStopServerMap() (map[string]interface{}, error)
+}
+
 func (opts UpdateOpts) ToServerUpdateMap() (map[string]interface{}, error) {
 	b, err := golangsdk.BuildRequestBody(opts, "")
 	if err != nil {
@@ -248,5 +292,38 @@ func AddNics(client *golangsdk.ServiceClient, id string, ops AddNicsOptsBuilder)
 
 func GetJobDetail(client *golangsdk.ServiceClient, jobID string) (r JobResult) {
 	_, r.Err = client.Get(jobURL(client, jobID), &r.Body, nil)
+	return
+}
+
+func RebootServer(client *golangsdk.ServiceClient, ops RebootServerOpsBuilder) (r JobResult) {
+	reqBody, err := ops.ToServerRebootServerMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(serverStatusPostURL(client), reqBody, &r.Body, nil)
+	return
+}
+
+func StartServer(client *golangsdk.ServiceClient, ops StartServerOpsBuilder) (r JobResult) {
+	reqBody, err := ops.ToServerStartServerMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(serverStatusPostURL(client), reqBody, &r.Body, nil)
+	return
+}
+
+func StopServer(client *golangsdk.ServiceClient, ops StopServerOpsBuilder) (r JobResult) {
+	reqBody, err := ops.ToServerStopServerMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+
+	_, r.Err = client.Post(serverStatusPostURL(client), reqBody, &r.Body, nil)
 	return
 }

--- a/openstack/bms/v1/baremetalservers/urls.go
+++ b/openstack/bms/v1/baremetalservers/urls.go
@@ -28,3 +28,7 @@ func deleteNicsURL(sc *golangsdk.ServiceClient, serverID string) string {
 func addNicsURL(sc *golangsdk.ServiceClient, serverID string) string {
 	return sc.ServiceURL(resourcePath, serverID, "nics")
 }
+
+func serverStatusPostURL(sc *golangsdk.ServiceClient) string {
+	return sc.ServiceURL(resourcePath, "action")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
bms instance support manage server status
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1.BMS server supports three operations to manage server status：start, stop and reboot.
2.The type field in the structure body supports HARD and SOFT. Only HARD takes effect.
```
