### PR TITLE
fix: omitempty for taint spec field "Value"

### DIFF
--- a/openstack/cce/v3/nodes/results.go
+++ b/openstack/cce/v3/nodes/results.go
@@ -114,7 +114,7 @@ type ExtNic struct {
 // TaintSpec to created nodes to configure anti-affinity
 type TaintSpec struct {
 	Key   string `json:"key" required:"true"`
-	Value string `json:"value" required:"true"`
+	Value string `json:"value,omitempty"`
 	// Available options are NoSchedule, PreferNoSchedule, and NoExecute
 	Effect string `json:"effect" required:"true"`
 }


### PR DESCRIPTION
This change is necessary in order to merge this PR https://github.com/huaweicloud/terraform-provider-huaweicloud/pull/3906

The change affects the structure of taints, which allows you to leave "Value" empty