### PR TITLE
feat(fgs): the datasource supports getting list of application templates

### DIFF
--- a/openstack/fgs/v2/application/requests.go
+++ b/openstack/fgs/v2/application/requests.go
@@ -1,0 +1,41 @@
+package application
+
+import (
+	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// ListOpts is the structure that used to query application template list.
+type ListOpts struct {
+	// Template runtime.
+	Runtime string `q:"runtime"`
+	// Template category.
+	Category string `q:"category"`
+	// The current query index.
+	Marker int `q:"marker"`
+	// Maximum number of templates to obtain in a request.
+	MaxItems int `q:"maxitems"`
+}
+
+// ListTemplates is a method to query the list of the application templates using given parameters.
+func ListTemplates(client *golangsdk.ServiceClient, opts ListOpts) ([]Template, error) {
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url := listURL(client) + query.String()
+	pages, err := pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		p := TemplatePage{pagination.MarkerPageBase{PageResult: r}}
+		p.MarkerPageBase.Owner = p
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+	pageInfo, err := extractPageInfo(pages)
+	if err != nil {
+		return nil, err
+	}
+	return pageInfo.Templates, nil
+}

--- a/openstack/fgs/v2/application/results.go
+++ b/openstack/fgs/v2/application/results.go
@@ -1,0 +1,83 @@
+package application
+
+import (
+	"strconv"
+
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// Template is the structure that represents the aplication template details.
+type Template struct {
+	// Template ID.
+	ID string `json:"id"`
+	// The name of template.
+	Name string `json:"name"`
+	// Template execution runtime.
+	Runtime string `json:"runtime"`
+	// The category of template.
+	Category string `json:"category"`
+	// Template image file(Base64-encoded).
+	Image string `json:"image"`
+	// Template description.
+	Description string `json:"description"`
+	// The type of the function application.
+	Type string `json:"type"`
+}
+
+// pageInfo is the structure that represents response of the ListTemplate method.
+type pageInfo struct {
+	// The list of templates.
+	Templates []Template `json:"templates"`
+	// Next record location.
+	NextMarker int `json:"next_marker"`
+	// Total number of application template.
+	Count int `json:"count"`
+}
+
+// TemplatePage represents the response pages of the ListTemplate method.
+type TemplatePage struct {
+	pagination.MarkerPageBase
+}
+
+// IsEmpty returns true if a ListResult no application template.
+func (r TemplatePage) IsEmpty() (bool, error) {
+	resp, err := extractPageInfo(r)
+	return resp.Count == 0, err
+}
+
+// LastMarker returns the last marker index in a pageInfo.
+func (r TemplatePage) LastMarker() (string, error) {
+	resp, err := extractPageInfo(r)
+	if err != nil {
+		return "", err
+	}
+	if resp.Count == 0 {
+		return "", nil
+	}
+	return strconv.Itoa(resp.NextMarker), nil
+}
+
+// NextPageURL generates the URL for the page of results after this one.
+func (r TemplatePage) NextPageURL() (string, error) {
+	currentURL := r.URL
+	mark, err := r.Owner.LastMarker()
+	if err != nil {
+		return "", err
+	}
+	if mark == "" {
+		return "", nil
+	}
+
+	q := currentURL.Query()
+	q.Set("marker", mark)
+	currentURL.RawQuery = q.Encode()
+
+	return currentURL.String(), nil
+}
+
+// extractPageInfo is a method which to extract the response of the page information.
+func extractPageInfo(r pagination.Page) (*pageInfo, error) {
+	var s pageInfo
+	err := r.(TemplatePage).Result.ExtractInto(&s)
+	return &s, err
+}

--- a/openstack/fgs/v2/application/urls.go
+++ b/openstack/fgs/v2/application/urls.go
@@ -1,0 +1,7 @@
+package application
+
+import "github.com/chnsz/golangsdk"
+
+func listURL(client *golangsdk.ServiceClient) string {
+	return client.ServiceURL("fgs/application/templates")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

 DataSource: huaweicloud_fgs_application_templates.
 The data source supports getting list of application templates.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. Use this data source to get the list of application templates.
```
