### PR TITLE
feat(apig): support binding domain names for specified API groups

### DIFF
--- a/openstack/apigw/dedicated/v2/apigroups/requests.go
+++ b/openstack/apigw/dedicated/v2/apigroups/requests.go
@@ -103,3 +103,39 @@ func Delete(client *golangsdk.ServiceClient, instanceId, groupId string) (r Dele
 	_, r.Err = client.Delete(resourceURL(client, instanceId, groupId), nil)
 	return
 }
+
+// AssociateDomainOpts is the structure that used to bind domain name to specified API group.
+type AssociateDomainOpts struct {
+	// The dedicated instance ID.
+	InstanceId string `json:"-" requires:"true"`
+	// The API group ID.
+	GroupId string `json:"-" requires:"true"`
+	// Custom domain name.
+	// The valid length is limited from 0 to 255 characters and must comply with the domian name specifications.
+	UrlDomain string `json:"url_domain" requires:"true"`
+	// The minimum TLS version that can be used to access the domain name, the default value is TLSv1.2.
+	// The valid value are as follows:
+	// + TLSv1.1.
+	// + TLSv1.2.
+	MinSSLVersion string `json:"min_ssl_version,omitempty"`
+	// Whether to enable redirection from HTTP to HTTPS, the default value is false.
+	IsHttpRedirectToHttps bool `json:"is_http_redirect_to_https,omitempty"`
+}
+
+// AssociateDomain is a method that used to bind domain name to specified API group.
+func AssociateDomain(client *golangsdk.ServiceClient, opts AssociateDomainOpts) (*AssociateDoaminResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssociateDoaminResp
+	_, err = client.Post(associateDomainURL(client, opts.InstanceId, opts.GroupId), b, &r, nil)
+	return &r, err
+}
+
+// AssociateDomain is a method that used to unbind domain name to specified API group.
+func DisAssociateDomain(client *golangsdk.ServiceClient, intanceId string, groupId string, domainId string) error {
+	_, err := client.Delete(disAssociateDomainURL(client, intanceId, groupId, domainId), nil)
+	return err
+}

--- a/openstack/apigw/dedicated/v2/apigroups/results.go
+++ b/openstack/apigw/dedicated/v2/apigroups/results.go
@@ -73,6 +73,8 @@ type UrlDomian struct {
 	//     TLSv1.1
 	//     TLSv1.2
 	MinSSLVersion string `json:"min_ssl_version"`
+	// Whether to enable redirection from HTTP to HTTPS.
+	IsHttpRedirectToHttps bool `json:"is_http_redirect_to_https"`
 }
 
 func (r commonResult) Extract() (*Group, error) {
@@ -95,4 +97,24 @@ func ExtractGroups(r pagination.Page) ([]Group, error) {
 // DeleteResult represents a result of the Delete method.
 type DeleteResult struct {
 	golangsdk.ErrResult
+}
+
+// AssociateDoaminResp is the structure that represents the API response of AssociateDomain method request.
+type AssociateDoaminResp struct {
+	// Domain ID.
+	ID string `json:"id"`
+	// Custom domain name.
+	UrlDoamin string `json:"url_domain"`
+	// CNAME resolution status of the domain name.
+	// + 1: not resolved
+	// + 2: resolving
+	// + 3: resolved
+	// + 4: resolving failed
+	Status int `json:"status"`
+	// The minimum SSL version supported.
+	MinSSLVersion string `json:"min_ssl_version"`
+	// Whether to enable redirection from HTTP to HTTPS.
+	IsHttpRedirectToHttps bool `json:"is_http_redirect_to_https"`
+	// Whether to enable client certificate verification.
+	VerifiedClientCertificateEnabled bool `json:"verified_client_certificate_enabled"`
 }

--- a/openstack/apigw/dedicated/v2/apigroups/urls.go
+++ b/openstack/apigw/dedicated/v2/apigroups/urls.go
@@ -11,3 +11,10 @@ func rootURL(c *golangsdk.ServiceClient, instanceId string) string {
 func resourceURL(c *golangsdk.ServiceClient, instanceId, groupId string) string {
 	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId)
 }
+
+func associateDomainURL(c *golangsdk.ServiceClient, instanceId string, groupId string) string {
+	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId, "domains")
+}
+func disAssociateDomainURL(c *golangsdk.ServiceClient, instanceId string, groupId string, domainId string) string {
+	return c.ServiceURL(rootPath, instanceId, "api-groups", groupId, "domains", domainId)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Support for associating domain names with  API group.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1.  up to five domain names can be associate to each API group.
```
