### PR TITLE
feat(elb): support new params for pool

### DIFF
--- a/openstack/elb/v3/pools/requests.go
+++ b/openstack/elb/v3/pools/requests.go
@@ -117,6 +117,12 @@ type CreateOpts struct {
 
 	// The ID of the VPC where the backend server group works
 	VpcId string `json:"vpc_id,omitempty"`
+
+	// The IP version
+	IpVersion string `json:"ip_version,omitempty"`
+
+	// Whether to enable deletion protection for the load balancer.
+	DeletionProtectionEnable *bool `json:"member_deletion_protection_enable,omitempty"`
 }
 
 type SlowStart struct {
@@ -192,6 +198,9 @@ type UpdateOpts struct {
 
 	// The ID of the VPC where the backend server group works
 	VpcId string `json:"vpc_id,omitempty"`
+
+	// Whether to enable deletion protection for the load balancer.
+	DeletionProtectionEnable *bool `json:"member_deletion_protection_enable,omitempty"`
 }
 
 // ToPoolUpdateMap builds a request body from UpdateOpts.

--- a/openstack/elb/v3/pools/results.go
+++ b/openstack/elb/v3/pools/results.go
@@ -10,16 +10,18 @@ import (
 // session to be processed by the same member as long as it is ative. Three
 // types of persistence are supported:
 //
-// SOURCE_IP:   With this mode, all connections originating from the same source
-//              IP address, will be handled by the same Member of the Pool.
+// SOURCE_IP: With this mode, all connections originating from the same source
+// IP address, will be handled by the same Member of the Pool.
+//
 // HTTP_COOKIE: With this persistence mode, the load balancing function will
-//              create a cookie on the first request from a client. Subsequent
-//              requests containing the same cookie value will be handled by
-//              the same Member of the Pool.
-// APP_COOKIE:  With this persistence mode, the load balancing function will
-//              rely on a cookie established by the backend application. All
-//              requests carrying the same cookie value will be handled by the
-//              same Member of the Pool.
+// create a cookie on the first request from a client. Subsequent
+// requests containing the same cookie value will be handled by
+// the same Member of the Pool.
+//
+// APP_COOKIE: With this persistence mode, the load balancing function will
+// rely on a cookie established by the backend application. All
+// requests carrying the same cookie value will be handled by the
+// same Member of the Pool.
 type SessionPersistence struct {
 	// The type of persistence mode.
 	Type string `json:"type"`
@@ -105,6 +107,9 @@ type Pool struct {
 
 	// Slow start.
 	SlowStart SlowStart `json:"slow_start"`
+
+	// Whether to enable deletion protection for the load balancer.
+	DeletionProtectionEnable bool `json:"member_deletion_protection_enable"`
 
 	// The type of the backend server group.
 	Type string `json:"type"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Support new params for `huaweicloud_elb_pool`, including `ip_version` and `member_deletion_protection_enable`.