### PR TITLE
feat(dli): support queue scaling policies to an elastic resource pool

### DIFF
--- a/openstack/dli/v3/elasticresourcepool/requests.go
+++ b/openstack/dli/v3/elasticresourcepool/requests.go
@@ -2,6 +2,7 @@ package elasticresourcepool
 
 import (
 	"github.com/chnsz/golangsdk"
+	"github.com/chnsz/golangsdk/pagination"
 )
 
 // AssociateQueueOpts is the structure that used to associate a queue with an elastic resource pool.
@@ -22,4 +23,75 @@ func AssociateQueue(c *golangsdk.ServiceClient, opts AssociateQueueOpts) (*Assoc
 	var r AssociateQueueResp
 	_, err = c.Post(associateQueueURl(c, opts.ElasticResourcePoolName), b, &r, nil)
 	return &r, err
+}
+
+// UpdateQueuePolicyOpts is the structure that used to modify the scaling policy of the queue associated with an elastic resource pool.
+type UpdateQueuePolicyOpts struct {
+	// The name of the elastic resource pool.
+	ElasticResourcePoolName string `json:"-" required:"true"`
+	// The name of queue.
+	QueueName string `json:"-" required:"true"`
+	// The list of the queue scaling policies.
+	QueueScalingPolicies []QueueScalingPolicy `json:"queue_scaling_policies" required:"true"`
+}
+
+// QueueScalingPolicy is the structure that represents the policy detail of specified queue associated with the specified elastic resource pool.
+type QueueScalingPolicy struct {
+	// The priority of the queue scaling policy. The valid value ranges from 1 to 100.
+	// The larger the value, the higher the priority.
+	Priority int `json:"priority" required:"true"`
+	// The effective time of the queue scaling policy.
+	ImpactStartTime string `json:"impact_start_time" required:"true"`
+	// The expiration time of the queue scaling policy.
+	ImpactStopTime string `json:"impact_stop_time" required:"true"`
+	// The minimum number of CUs allowed by the scaling policy.
+	MinCu int `json:"min_cu" required:"true"`
+	// The maximum number of CUs allowed by the scaling policy.
+	MaxCu int `json:"max_cu" required:"true"`
+}
+
+// UpdateElasticResourcePoolQueuePolicy is a method to modify the scaling policy of the queue associated with
+// specified elastic resource pool using given parameters.
+func UpdateElasticResourcePoolQueuePolicy(c *golangsdk.ServiceClient, opts UpdateQueuePolicyOpts) (*AssociateQueueResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r AssociateQueueResp
+	_, err = c.Put(queueScalingPolicyURL(c, opts.ElasticResourcePoolName, opts.QueueName), b, &r, nil)
+	return &r, err
+}
+
+// ListElasticResourcePoolQueuesOpts is the structure used to query the list of queue scaling policies in an elastic resource pool.
+type ListElasticResourcePoolQueuesOpts struct {
+	// The name of the elastic resource pool.
+	ElasticResourcePoolName string `json:"-" required:"true"`
+	// The name of the queue.
+	QueueName string `q:"queue_name"`
+	// Offset from which the query starts. Default to 0.
+	Offset int `q:"offset"`
+	// The number of items displayed on each page. Default to 100.
+	Limit int `q:"limit"`
+}
+
+// ListElasticResourcePoolQueues is a method to query all queue scaling policies in an elastic resource pool using given parameters.
+func ListElasticResourcePoolQueues(c *golangsdk.ServiceClient, opts ListElasticResourcePoolQueuesOpts) ([]Queue, error) {
+	url := associateQueueURl(c, opts.ElasticResourcePoolName)
+	query, err := golangsdk.BuildQueryString(opts)
+	if err != nil {
+		return nil, err
+	}
+	url += query.String()
+
+	pages, err := pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		p := QueuePage{pagination.OffsetPageBase{PageResult: r}}
+		return p
+	}).AllPages()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ExtractQueues(pages)
 }

--- a/openstack/dli/v3/elasticresourcepool/results.go
+++ b/openstack/dli/v3/elasticresourcepool/results.go
@@ -1,9 +1,55 @@
 package elasticresourcepool
 
-// AssociateQueueResp is the structure that represents response of the AssociateElasticResourcePool method.
+import (
+	"github.com/chnsz/golangsdk/pagination"
+)
+
+// AssociateQueueResp is the structure that represents response of the AssociateElasticResourcePool or UpdateElasticResourcePoolQueuePolicy method.
 type AssociateQueueResp struct {
 	// Whether the request is successfully sent. Value true indicates that the request is successfully sent.
 	IsSuccess bool `json:"is_success"`
 	// System prompt. If execution succeeds, the parameter setting may be left blank.
 	Message string `json:"message"`
+}
+
+// QueuePage is a page structure that represents each page information.
+type QueuePage struct {
+	pagination.OffsetPageBase
+}
+
+// QueuesResp is the structure that represents response of the ListElasticResourcePoolQueues method.
+type QueuesResp struct {
+	// Whether the request is successfully sent. Value true indicates that the request is successfully sent.
+	IsSuccess bool `json:"is_success"`
+	// System prompt. If execution succeeds, the parameter setting may be left blank.
+	Message string `json:"message"`
+	// The list of the queues associated with the specified elastic resource pool.
+	Queues []Queue `json:"queues"`
+	// The number of queues bound to the elastic resource pool.
+	Count int `json:"count"`
+}
+
+// QueuesResp is the structure that represents the queue detail associated with the specified elastic resource pool.
+type Queue struct {
+	// The queue name.
+	QueueName string `json:"queue_name"`
+	// The enterprise project ID of the queue.
+	EnterpriseProjectId string `json:"enterprise_project_id"`
+	// The queue type.
+	QueueType string `json:"queue_type"`
+	// The list of scaling policies of the queue.
+	QueueScalingPolicies []QueueScalingPolicy `json:"queue_scaling_policies"`
+	// The owner of the queue.
+	Owner string `json:"owner"`
+	// Tht creation time of the queue.
+	CreatedAt int `json:"create_time"`
+	// The engine type ot the queue.
+	Engine string `json:"engine"`
+}
+
+// ExtractQueues is a method to extract the list of queues associated with elastic resource pool.
+func ExtractQueues(r pagination.Page) ([]Queue, error) {
+	var s []Queue
+	err := r.(QueuePage).Result.ExtractIntoSlicePtr(&s, "queues")
+	return s, err
 }

--- a/openstack/dli/v3/elasticresourcepool/urls.go
+++ b/openstack/dli/v3/elasticresourcepool/urls.go
@@ -5,3 +5,7 @@ import "github.com/chnsz/golangsdk"
 func associateQueueURl(c *golangsdk.ServiceClient, name string) string {
 	return c.ServiceURL("elastic-resource-pools", name, "queues")
 }
+
+func queueScalingPolicyURL(c *golangsdk.ServiceClient, elasticResourcePoolName, queueName string) string {
+	return c.ServiceURL("elastic-resource-pools", elasticResourcePoolName, "queues", queueName)
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The resource supports configuring the queue scaling policy to the specified elastic resource pool.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

the API document states that the default value of limit is 100, but if offset is specified without limit,
paging will not take effect.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
