### PR TITLE
feat(dli): the flink sql job supports generating stream graphs

### DIFF
--- a/openstack/dli/v1/flinkjob/requests.go
+++ b/openstack/dli/v1/flinkjob/requests.go
@@ -97,6 +97,8 @@ type CreateSqlJobOpts struct {
 	RuntimeConfig string `json:"runtime_config,omitempty"`
 	// Label of a Flink SQL job. For details, see Table 3.
 	Tags []tags.ResourceTag `json:"tags"`
+	// Flink version. The valid value is `1.1`0 or `1.12`.
+	FlinkVersion string `json:"flink_version,omitempty"`
 }
 
 type UpdateSqlJobOpts struct {
@@ -162,16 +164,18 @@ type UpdateSqlJobOpts struct {
 	// Number of slots in each TaskManager. The default value is (parallel_number*tm_cus)/(cu_number-manager_cu_number).
 	TmSlotNum *int `json:"tm_slot_num,omitempty"`
 	// Degree of parallelism (DOP) of an operator.
-	OperatorConfig string `json:"operator_config,omitempty"`
+	OperatorConfig string `json:"operator_config"`
 	// Whether the abnormal restart is recovered from the checkpoint.
 	ResumeCheckpoint *bool `json:"resume_checkpoint,omitempty"`
 	// Maximum number of retry times upon exceptions. The unit is times/hour. Value range: -1 or greater than 0.
 	// The default value is -1, indicating that the number of times is unlimited.
 	ResumeMaxNum *int `json:"resume_max_num,omitempty"`
 	// Traffic or hit ratio of each operator, which is a character string in JSON format.
-	StaticEstimatorConfig string `json:"static_estimator_config,omitempty"`
+	StaticEstimatorConfig string `json:"static_estimator_config"`
 	// Customizes optimization parameters when a Flink job is running.
 	RuntimeConfig string `json:"runtime_config,omitempty"`
+	// Flink version. The valid value is `1.1`0 or `1.12`.
+	FlinkVersion string `json:"flink_version,omitempty"`
 }
 
 type ListOpts struct {

--- a/openstack/dli/v1/flinkjob/results.go
+++ b/openstack/dli/v1/flinkjob/results.go
@@ -176,6 +176,10 @@ type JobConfBase struct {
 	Feature          string `json:"feature"`
 	FlinkVersion     string `json:"flink_version"`
 	Image            string `json:"image"`
+	// Degree of parallelism (DOP) of an operator.
+	OperatorConfig string `json:"operator_config"`
+	// The traffic or hit rate configuration of each operator.
+	StaticEstimatorConfig string `json:"static_estimator_config"`
 }
 
 type ListResp struct {

--- a/openstack/dli/v3/flinkjob/requests.go
+++ b/openstack/dli/v3/flinkjob/requests.go
@@ -1,0 +1,49 @@
+package flinkjob
+
+import (
+	"github.com/chnsz/golangsdk"
+)
+
+// StreamGraphOpts is the structure that represents used to generate a static stream graph or simplified stream graph.
+type StreamGraphOpts struct {
+	// The job ID of the flink job.
+	JobId string `json:"-" required:"true"`
+	// Stream SQL statement.
+	SqlBody string `json:"sql_body" required:"true"`
+	// The total number of CUs.
+	CuNumber *int `json:"cu_number,omitempty"`
+	// The number of CUs of the management unit.
+	ManagerCuNumber *int `json:"manager_cu_number,omitempty"`
+	// The number of parallel jobs
+	ParallelNumber *int `json:"parallel_number,omitempty"`
+	// The number of CUs in a taskManager.
+	TmCus *int `json:"tm_cus,omitempty"`
+	// The number of slots in a taskManager.
+	TmSlotNum *int `json:"tm_slot_num,omitempty"`
+	// The operator configurations.
+	OperatorConfig string `json:"operator_config,omitempty"`
+	// Whether to estimate static resources.
+	StaticEstimator *bool `json:"static_estimator,omitempty"`
+	// Job type. Only flink_opensource_sql_job job is supported.
+	JobType string `json:"job_type,omitempty"`
+	// Stream graph type. The valid values aer as follows:
+	// + simple_graph: Simplified stream graph.
+	// + job_graph: Static stream graph.
+	GraphType string `json:"graph_type,omitempty"`
+	// Traffic or hit ratio of each operator, which is a string in JSON format.
+	StaticEstimatorConfig string `json:"static_estimator_config,omitempty"`
+	// Flink version. Currently, only 1.10 and 1.12 are supported.
+	FlinkVersion string `json:"flink_version,omitempty"`
+}
+
+// CreateFlinkSqlJobGraph is a method to generate a stream graph for a Flink SQL job using given parameters.
+func CreateFlinkSqlJobGraph(c *golangsdk.ServiceClient, opts StreamGraphOpts) (*streamGraphResp, error) {
+	b, err := golangsdk.BuildRequestBody(opts, "")
+	if err != nil {
+		return nil, err
+	}
+
+	var r streamGraphResp
+	_, err = c.Post(streamGraphURL(c, opts.JobId), b, &r, &golangsdk.RequestOpts{})
+	return &r, err
+}

--- a/openstack/dli/v3/flinkjob/result.go
+++ b/openstack/dli/v3/flinkjob/result.go
@@ -1,0 +1,12 @@
+package flinkjob
+
+type streamGraphResp struct {
+	// Indicates whether the request is successfully executed. Value true indicates that the request is successfully executed.
+	IsSuccess bool `json:"is_success"`
+	// System prompt. If execution succeeds, the message may be left blank.
+	Message string `json:"message"`
+	// Error codes.
+	ErrorCode string `json:"error_code"`
+	// Description of a static stream graph.
+	StreamGraph string `json:"stream_graph"`
+}

--- a/openstack/dli/v3/flinkjob/urls.go
+++ b/openstack/dli/v3/flinkjob/urls.go
@@ -1,0 +1,7 @@
+package flinkjob
+
+import "github.com/chnsz/golangsdk"
+
+func streamGraphURL(c *golangsdk.ServiceClient, jobId string) string {
+	return c.ServiceURL("streaming/jobs", jobId, "gen-graph")
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

1. The flink sql job supports generating stream graphs.
2. The flink sql job supports `flink_version` parameter.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
3. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. add a API that is used to generate a static stream graph or simplified stream graph  for a Flink SQL job.
2. the UpdateSqlJobOpts.OperatorConfig and UpdateSqlJobOpts.StaticEstimatorConfig parameters can be set to empty string.

```
