### PR TITLE
feat(modelarts/notebook): support new params for volume strcuture

### DIFF
--- a/openstack/modelarts/v1/notebook/requests.go
+++ b/openstack/modelarts/v1/notebook/requests.go
@@ -31,6 +31,7 @@ type VolumeReq struct {
 	Ownership string `json:"ownership" required:"true"`
 	Capacity  *int   `json:"capacity,omitempty"`
 	Uri       string `json:"uri,omitempty"`
+	ID        string `json:"id,omitempty"`
 }
 
 type ListOpts struct {

--- a/openstack/modelarts/v1/notebook/results.go
+++ b/openstack/modelarts/v1/notebook/results.go
@@ -83,6 +83,8 @@ type VolumeRes struct {
 	MountPath string `json:"mount_path"`
 	Ownership string `json:"ownership"`
 	Status    string `json:"status"`
+	URI       string `json:"uri"`
+	ID        string `json:"id"`
 }
 
 type ListNotebooks struct {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The EFS turbo creation needs the volume.id parameter and it is a required param for the dedicated notebook

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
support new params for volume strcuture
```
