### PR TITLE
feat(WAF): WAF dedicated sdk support new field

### DIFF
--- a/openstack/waf_hw/v1/premium_instances/requests.go
+++ b/openstack/waf_hw/v1/premium_instances/requests.go
@@ -22,7 +22,6 @@ type CreateInstanceOpts struct {
 	Arch          string   `json:"arch" required:"true"`
 	NamePrefix    string   `json:"instancename" required:"true"`
 	Specification string   `json:"specification" required:"true"`
-	CpuFlavor     string   `json:"cpu_flavor" required:"true"`
 	VpcId         string   `json:"vpc_id" required:"true"`
 	SubnetId      string   `json:"subnet_id" required:"true"`
 	SecurityGroup []string `json:"security_group" required:"true"`
@@ -32,6 +31,8 @@ type CreateInstanceOpts struct {
 	ClusterId     string   `json:"cluster_id,omitempty"`
 	PoolId        string   `json:"pool_id,omitempty"`
 	ResTenant     *bool    `json:"res_tenant,omitempty"`
+	CpuFlavor     string   `json:"cpu_flavor,omitempty"`
+	AntiAffinity  *bool    `json:"anti_affinity,omitempty"`
 }
 
 // ListInstanceOpts the parameters in the querying request.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

WAF dedicated sdk support new field.
- Change `cpu_flavor` from required to omitempty.
- Add new field `anti_affinity`. This field does not have response value.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
