### PR TITLE
fix(er/attachment): invalid param label for resource type

### DIFF
--- a/openstack/er/v3/attachments/results.go
+++ b/openstack/er/v3/attachments/results.go
@@ -52,7 +52,7 @@ type Attachment struct {
 	// + vgw: virtual gateway of cloud private line.
 	// + peering: Peering connection, through the cloud connection (CC) to load enterprise routers in different regions
 	//   to create a peering connection.
-	ResourceType string `q:"resource_type"`
+	ResourceType string `json:"resource_type"`
 	// The project ID to which the attachment is belongs.
 	ResourceProjectId string `json:"resource_project_id"`
 	// Whether this attachment is associated.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The JSON label of parameter 'resource_type' is invalid, should be 'json', but got 'q'.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
