### PR TITLE
fix(vpcep): remove policy_document field

### DIFF
--- a/openstack/vpcep/v1/endpoints/requests.go
+++ b/openstack/vpcep/v1/endpoints/requests.go
@@ -40,8 +40,6 @@ type CreateOpts struct {
 	Description string `json:"description,omitempty"`
 	// Specifies the endpoint policy information for the gateway type
 	PolicyStatement []PolicyStatement `json:"policy_statement,omitempty"`
-	// Specifies the endpoint policy information
-	PolicyDocument string `json:"policy_document,omitempty"`
 	// Specifies the IP version
 	IPVersion string `json:"ip_version,omitempty"`
 	// Specifies the IPv6 address
@@ -115,8 +113,6 @@ type UpdatePolicyOptsBuilder interface {
 type UpdatePolicyOpts struct {
 	// Specifies the endpoint policy information for the gateway type
 	PolicyStatement []PolicyStatement `json:"policy_statement,omitempty"`
-	// Specifies the endpoint policy information
-	PolicyDocument string `json:"policy_document,omitempty"`
 }
 
 // UpdatePolicyOptsMap assembles a request body based on the contents of a UpdatePolicyOpts.

--- a/openstack/vpcep/v1/endpoints/results.go
+++ b/openstack/vpcep/v1/endpoints/results.go
@@ -55,8 +55,6 @@ type Endpoint struct {
 	Description string `json:"description"`
 	// The gateway type endpoint policy information
 	PolicyStatement []PolicyStatementResult `json:"policy_statement"`
-	// the endpoint policy information
-	PolicyDocument string `json:"policy_document"`
 	// The cluster ID associated with the instance
 	EndpointPoolID string `json:"endpoint_pool_id"`
 	// The public border group information of the terminal node corresponding to the pool


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

The field (policy_document) type provided in the API document is different from the type returned
by the API, as a result, an error is reported when the resource is imported.
![image](https://github.com/user-attachments/assets/a2b82284-b8ce-4abe-9809-786cbae61b46)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
