### PR TITLE
fix(workspace/app): the request param keys are invalid for standby domain

### DIFF
--- a/openstack/workspace/v2/services/requests.go
+++ b/openstack/workspace/v2/services/requests.go
@@ -49,16 +49,16 @@ type Domain struct {
 	AcitveDomainName string `json:"active_domain_name,omitempty"`
 	// The IP address of the standby domain controller.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDomainIp string `json:"standy_domain_ip,omitempty"`
+	StandyDomainIp string `json:"standby_domain_ip,omitempty"`
 	// The name of the standby domain controller.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDomainName string `json:"standy_domain_name,omitempty"`
+	StandyDomainName string `json:"standby_domain_name,omitempty"`
 	// Primary DNS IP address.
 	// It needs to be configured when the domain type is LOCAL_AD.
 	ActiveDnsIp string `json:"active_dns_ip,omitempty"`
 	// Backup DNS IP address.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDnsIp string `json:"standy_dns_ip,omitempty"`
+	StandyDnsIp string `json:"standby_dns_ip,omitempty"`
 	// Whether to delete the corresponding computer object on AD while deleting the desktop.
 	// + 0 means not delete
 	// + 1 means delete.

--- a/openstack/workspace/v2/services/results.go
+++ b/openstack/workspace/v2/services/results.go
@@ -123,16 +123,16 @@ type DomainResp struct {
 	AcitveDomainName string `json:"active_domain_name"`
 	// The IP address of the standby domain controller.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDomainIp string `json:"standy_domain_ip"`
+	StandyDomainIp string `json:"standby_domain_ip"`
 	// The name of the standby domain controller.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDomainName string `json:"standy_domain_name"`
+	StandyDomainName string `json:"standby_domain_name"`
 	// Primary DNS IP address.
 	// It needs to be configured when the domain type is LOCAL_AD.
 	ActiveDnsIp string `json:"active_dns_ip"`
 	// Backup DNS IP address.
 	// It needs to be configured when the domain type is LOCAL_AD and the standby node is configured.
-	StandyDnsIp string `json:"standy_dns_ip"`
+	StandyDnsIp string `json:"standby_dns_ip"`
 	// Whether to delete the corresponding computer object on AD while deleting the desktop.
 	// + 0 means not delete
 	// + 1 means delete.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Invalid request parameter keyword `standy`, should be `standby`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. Invalid request parameter keyword `standy`, should be `standby`.
```
