### PR TITLE
feat: golangsdk supports derivative algorithm capabilities

### DIFF
--- a/auth/core/signer/derived_signer.go
+++ b/auth/core/signer/derived_signer.go
@@ -1,0 +1,117 @@
+package signer
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"golang.org/x/crypto/hkdf"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	DerivedDateFormat = "20060102"
+	AlgorithmV11      = "V11-HMAC-SHA256"
+)
+
+// Derived algorithm structure, all fields are required
+type DerivedSigner struct {
+	Key                    string
+	Secret                 string
+	DerivedAuthServiceName string
+	RegionID               string
+}
+
+// Sign Use derivative algorithms to authenticate AK/SK
+func (s DerivedSigner) Sign(request *http.Request) error {
+	if s.DerivedAuthServiceName == "" {
+		return errors.New("DerivedAuthServiceName is required in credentials when using derived auth")
+	}
+	if s.RegionID == "" {
+		return errors.New("RegionID is required in credentials when using derived auth")
+	}
+
+	var (
+		t    time.Time
+		err  error
+		date string
+	)
+
+	if date = request.Header.Get(HeaderXDateTime); date != "" {
+		t, err = time.Parse(DateFormat, date)
+	}
+	if err != nil || date == "" {
+		t = time.Now()
+		request.Header.Set(HeaderXDateTime, t.UTC().Format(DateFormat))
+	}
+
+	signedHeaders := SignedHeaders(request)
+	canonicalRequest, err := CanonicalRequest(request, signedHeaders)
+	if err != nil {
+		return err
+	}
+
+	info := t.UTC().Format(DerivedDateFormat) + "/" + s.RegionID + "/" + s.DerivedAuthServiceName
+	stringToSignStr, err := s.stringToSign(canonicalRequest, info, t)
+	if err != nil {
+		return err
+	}
+
+	derivationKey, err := s.getDerivationKey(info)
+	if err != nil {
+		return err
+	}
+
+	sig, err := s.signStringToSign(stringToSignStr, []byte(derivationKey))
+	if err != nil {
+		return err
+	}
+
+	authValueStr := s.authHeaderValue(sig, s.Key, info, signedHeaders)
+	request.Header.Set(HeaderXAuthorization, authValueStr)
+
+	return nil
+}
+
+func (s DerivedSigner) stringToSign(canonicalRequest, info string, t time.Time) (string, error) {
+	hash := sha256.New()
+	_, err := hash.Write([]byte(canonicalRequest))
+	if err != nil {
+		return "", err
+	}
+
+	hashSum := hash.Sum(nil)
+	canonicalRequestHash := hex.EncodeToString(hashSum)
+
+	return fmt.Sprintf("%s\n%s\n%s\n%s", AlgorithmV11, t.UTC().Format(DateFormat), info, canonicalRequestHash), nil
+}
+
+func (s DerivedSigner) getDerivationKey(info string) (string, error) {
+	hash := sha256.New
+	derivationKeyReader := hkdf.New(hash, []byte(s.Secret), []byte(s.Key), []byte(info))
+	derivationKey := make([]byte, 32)
+	_, err := io.ReadFull(derivationKeyReader, derivationKey)
+	return hex.EncodeToString(derivationKey), err
+}
+
+func (s DerivedSigner) signStringToSign(stringToSign string, signingKey []byte) (string, error) {
+	hash := hmac.New(sha256.New, signingKey)
+	if _, err := hash.Write([]byte(stringToSign)); err != nil {
+		return "", err
+	}
+	hm := hash.Sum(nil)
+	return fmt.Sprintf("%x", hm), nil
+}
+
+func (s DerivedSigner) authHeaderValue(signature, accessKey, info string, signedHeaders []string) string {
+	return fmt.Sprintf("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		AlgorithmV11,
+		accessKey,
+		info,
+		strings.Join(signedHeaders, ";"),
+		signature)
+}

--- a/auth/derived_signer_helper.go
+++ b/auth/derived_signer_helper.go
@@ -1,0 +1,18 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/chnsz/golangsdk/auth/core/signer"
+)
+
+// SignDerived method is used to generate a derived authorization header and set it to the request header.
+func SignDerived(request *http.Request, ak, sk, derivedAuthServiceName, regionID string) error {
+	SignObj := signer.DerivedSigner{
+		Key:                    ak,
+		Secret:                 sk,
+		DerivedAuthServiceName: derivedAuthServiceName,
+		RegionID:               regionID,
+	}
+	return SignObj.Sign(request)
+}

--- a/auth_aksk_options.go
+++ b/auth_aksk_options.go
@@ -30,6 +30,10 @@ type AKSKAuthOptions struct {
 	SecretKey     string //Secret key
 	SecurityToken string //Security Token for temporary Access Key
 
+	IsDerived bool // Whether to enable the derivative algorithm
+
+	DerivedAuthServiceName string // Derivative algorithm service name. Required for derivative algorithm.
+
 	// AgencyNmae is the name of agnecy
 	AgencyName string
 

--- a/provider_client.go
+++ b/provider_client.go
@@ -312,7 +312,15 @@ func (client *ProviderClient) doRequest(method, url string, options *RequestOpts
 	prereqtok := req.Header.Get("X-Auth-Token")
 
 	if client.AKSKAuthOptions.AccessKey != "" {
-		if err := auth.Sign(req, client.AKSKAuthOptions.AccessKey, client.AKSKAuthOptions.SecretKey); err != nil {
+		var err error
+		if client.AKSKAuthOptions.IsDerived {
+			err = auth.SignDerived(req, client.AKSKAuthOptions.AccessKey, client.AKSKAuthOptions.SecretKey,
+				client.AKSKAuthOptions.DerivedAuthServiceName, client.AKSKAuthOptions.Region)
+		} else {
+			err = auth.Sign(req, client.AKSKAuthOptions.AccessKey, client.AKSKAuthOptions.SecretKey)
+		}
+
+		if err != nil {
 			return nil, err
 		}
 		if client.AKSKAuthOptions.ProjectId != "" {

--- a/testing/auth_test.go
+++ b/testing/auth_test.go
@@ -1,0 +1,159 @@
+package testing
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/chnsz/golangsdk/auth"
+	th "github.com/chnsz/golangsdk/testhelper"
+)
+
+const (
+	ak       = "AccessKey"
+	sk       = "SecretKey"
+	service  = "demo"
+	regionId = "test-region-1"
+	host     = "example.huaweicloud.com"
+	endpoint = "https://" + host
+	path     = "/path"
+)
+
+type TestBody struct {
+	Name string
+	Id   int
+}
+
+type TestParam struct {
+	Name, Method, Endpoint, Path string
+	Body                         interface{}
+	Queries                      map[string]interface{}
+	Headers                      map[string]string
+}
+
+type TestCase struct {
+	TestParam
+	Expected string
+}
+
+var (
+	testParam1 = TestParam{
+		Name:     "test1",
+		Method:   "GET",
+		Endpoint: endpoint,
+		Path:     path,
+		Body:     nil,
+		Queries:  map[string]interface{}{"limit": 1},
+		Headers:  map[string]string{"X-Sdk-Date": "20060102T150405Z", "TEST_UNDERSCORE": "TEST_VALUE"},
+	}
+	testParam2 = TestParam{
+		Name:     "test2",
+		Method:   "POST",
+		Endpoint: endpoint,
+		Path:     path,
+		Body:     &TestBody{Name: "test", Id: 1},
+		Queries:  map[string]interface{}{"key": "value"},
+		Headers:  map[string]string{"X-Sdk-Date": "20060102T150405Z", "TEST_UNDERSCORE": "TEST_VALUE", "Content-Type": "application/json"},
+	}
+)
+
+func buildRequestBody(tc TestCase) io.Reader {
+	if tc.Body == nil {
+		return nil
+	}
+
+	jsonData, err := json.Marshal(tc.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	return bytes.NewReader(jsonData)
+}
+
+func buildRequestHeaders(tc TestCase) http.Header {
+	headers := make(map[string][]string)
+	if tc.Headers != nil {
+		for k, v := range tc.Headers {
+			headers[k] = []string{v}
+		}
+	}
+	return headers
+}
+
+func buildRequestPath(tc TestCase) string {
+	queryParams := ""
+	if tc.Queries != nil {
+		for k, v := range tc.Queries {
+			queryParams += fmt.Sprintf("&%s=%v", k, v)
+		}
+	}
+
+	if queryParams != "" {
+		queryParams = "?" + queryParams[1:]
+	}
+
+	return tc.Path + queryParams
+}
+
+func buildReqWithTestcase(tc TestCase) *http.Request {
+	request, err := http.NewRequest(tc.Method, buildRequestPath(tc), buildRequestBody(tc))
+	if err != nil {
+		panic(err)
+	}
+
+	request.Header = buildRequestHeaders(tc)
+	return request
+}
+
+func TestSigner_Sign(t *testing.T) {
+	cases := []TestCase{
+		{
+			TestParam: testParam1,
+			Expected: "SDK-HMAC-SHA256 Access=AccessKey, SignedHeaders=test_underscore;x-sdk-date," +
+				" Signature=daeadcf4a306599f7422401cc55d3718a23ef159fed370c62c551a2c45ae9655",
+		},
+		{
+			TestParam: testParam2,
+			Expected: "SDK-HMAC-SHA256 Access=AccessKey, SignedHeaders=content-type;test_underscore;x-sdk-date," +
+				" Signature=0238c3bedddfe8bf113c7530f783322380dedf720d514861623cfe5f73aa8f64",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			req := buildReqWithTestcase(c)
+			err := auth.Sign(req, ak, sk)
+			th.CheckNoErr(t, err)
+			th.AssertEquals(t, c.Expected, req.Header.Get("Authorization"))
+		})
+	}
+}
+
+func TestDerivedSigner_Sign(t *testing.T) {
+	cases := []TestCase{
+		{
+			TestParam: testParam1,
+			Expected: "V11-HMAC-SHA256 Credential=AccessKey/20060102/test-region-1/demo," +
+				" SignedHeaders=test_underscore;x-sdk-date," +
+				" Signature=00196d6926ef54489f9f1a1bdfa24870cadbf0af55cc1dffe26574341f1da7b0",
+		},
+		{
+			TestParam: testParam2,
+			Expected: "V11-HMAC-SHA256 Credential=AccessKey/20060102/test-region-1/demo," +
+				" SignedHeaders=content-type;test_underscore;x-sdk-date," +
+				" Signature=ec6f411f852fb2badae3d4927dd1a559e3a3f02a7689527a9a116f8edc7ce3fb",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			req := buildReqWithTestcase(c)
+			err := auth.SignDerived(req, ak, sk, service, regionId)
+			th.CheckNoErr(t, err)
+			th.AssertEquals(t, c.Expected, req.Header.Get("Authorization"))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

golangsdk supports derivative algorithm capabilities.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

```
go test -v -run TestSigner_Sign ./testing/
=== RUN   TestSigner_Sign
=== RUN   TestSigner_Sign/test1
=== RUN   TestSigner_Sign/test2
--- PASS: TestSigner_Sign (0.00s)
    --- PASS: TestSigner_Sign/test1 (0.00s)
    --- PASS: TestSigner_Sign/test2 (0.00s)
PASS
ok      github.com/chnsz/golangsdk/testing      0.007s
```

```
go test -v -run TestDerivedSigner_Sign ./testing/
=== RUN   TestDerivedSigner_Sign
=== RUN   TestDerivedSigner_Sign/test1
=== RUN   TestDerivedSigner_Sign/test2
--- PASS: TestDerivedSigner_Sign (0.00s)
    --- PASS: TestDerivedSigner_Sign/test1 (0.00s)
    --- PASS: TestDerivedSigner_Sign/test2 (0.00s)
PASS
ok      github.com/chnsz/golangsdk/testing      0.007s
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
