### PR TITLE
chore(fgs/function): deprecate the depend list and support new param

### DIFF
--- a/openstack/fgs/v2/function/requests.go
+++ b/openstack/fgs/v2/function/requests.go
@@ -140,11 +140,13 @@ type UpdateOptsBuilder interface {
 
 // Function struct for update
 type UpdateCodeOpts struct {
-	CodeType     string           `json:"code_type" required:"true"`
-	CodeUrl      string           `json:"code_url,omitempty"`
-	DependList   []string         `json:"depend_list,omitempty"`
-	CodeFileName string           `json:"code_filename,omitempty"`
-	FuncCode     FunctionCodeOpts `json:"func_code,omitempty"`
+	CodeType          string           `json:"code_type" required:"true"`
+	CodeUrl           string           `json:"code_url,omitempty"`
+	DependVersionList []string         `json:"depend_version_list,omitempty"`
+	CodeFileName      string           `json:"code_filename,omitempty"`
+	FuncCode          FunctionCodeOpts `json:"func_code,omitempty"`
+	// Deprecated parameter.
+	DependList []string `json:"depend_list,omitempty"`
 }
 
 func (opts UpdateCodeOpts) ToUpdateMap() (map[string]interface{}, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The configuration of the parameter 'depend_list' cannot obtain by the attribute 'depend_version_list', and just only deprecate parameter 'depend_list' can obtain it.
So if we want to obtain the corresponding values during the attribute 'depend_version_list', the request parameter 'depend_version_list' must be used.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. deprecate the depend list and support new param.
```
