### PR TITLE
fix(dns): fix PTR record description cannot be modified to empty

### DIFF
--- a/openstack/dns/v2/ptrrecords/requests.go
+++ b/openstack/dns/v2/ptrrecords/requests.go
@@ -22,7 +22,7 @@ type CreateOpts struct {
 	PtrName string `json:"ptrdname" required:"true"`
 
 	// Description of the ptr.
-	Description string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 
 	// TTL is the time to live of the ptr.
 	TTL int `json:"-"`


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fixed the issue that the description of PTR record cannot be modified to empty.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
