### PR TITLE
fix(apig/channel): update the reference of the param member_group_name

### DIFF
--- a/openstack/apigw/dedicated/v2/channels/requests.go
+++ b/openstack/apigw/dedicated/v2/channels/requests.go
@@ -121,7 +121,7 @@ type MemberInfo struct {
 	// Defaults to false.
 	IsBackup *bool `json:"is_backup,omitempty"`
 	// Backend server group name. The server group facilitates backend service address modification.
-	GroupName string `json:"group_name,omitempty"`
+	GroupName string `json:"member_group_name,omitempty"`
 	// Backend server status.
 	// + 1: available
 	// + 2: unavailable


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
The parameter reference of the member group name is incorrect, should be 'member_group_name', not 'group_name'.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. update the reference of the param member_group_name.
```
