### PR TITLE
feat(smn): new parameter extension.header is supported

### DIFF
--- a/openstack/smn/v2/subscriptions/requests.go
+++ b/openstack/smn/v2/subscriptions/requests.go
@@ -32,6 +32,21 @@ type ExtensionSpec struct {
 	ClientSecret string `json:"client_secret,omitempty"`
 	Keyword      string `json:"keyword,omitempty"`
 	SignSecret   string `json:"sign_secret,omitempty"`
+	// The HTTP/HTTPS headers to be added to the requests when the message is delivered via HTTP/HTTPS.
+	// This field is used when `protocol` is set to **http** or **https**.
+	// The following requirements apply to the header keys and values:
+	// + Header keys must:
+	//   - Contain only letters, numbers, and hyphens (`[A-Za-z0-9-]`)
+	//   - Not end with a hyphen
+	//   - Not contain consecutive hyphens
+	//   - Start with "x-" (e.g., "x-abc-cba", "x-abc")
+	//   - Not start with "x-smn"
+	//   - Be case-insensitive (e.g., "X-Custom" and "x-custom" are considered the same)
+	//   - Not be duplicated
+	// + Maximum of 10 key-value pairs allowed
+	// + Total length of all keys and values combined must not exceed 1024 characters
+	// + Values must only contain ASCII characters (no Chinese or other Unicode characters, spaces are allowed)
+	Header map[string]interface{} `json:"header,omitempty"`
 }
 
 func (ops CreateOps) ToSubscriptionCreateMap() (map[string]interface{}, error) {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Supplement a parameter 'extension.header' (type map) in to smn request structure.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
1. new parameter extension.header is supported.
```
