### PR TITLE
feat(obs): upgrade obs sdk version to 3.26.3

### DIFF
--- a/openstack/obs/CHANGELOG
+++ b/openstack/obs/CHANGELOG
@@ -1,3 +1,88 @@
+Version 3.26.3
+
+New Features:
+
+1. Added new APIs for Object Tagging.
+2. Supported encryption configuration during bucket creation.
+
+Bug Fixes:
+
+1. Fixed an issue where Content-Length was set to 0 when uploading a 0KB object using chunked mode.
+
+-----------------------------------------------------------------------------------
+
+Version 3.25.9
+
+New Features:
+
+Documentation & Demo:
+
+Resolved Issues:
+1. Fixed an issue where the first byte could not be downloaded using range.
+
+-----------------------------------------------------------------------------------
+
+Version 3.25.4
+
+New Features:
+1. Supports passing metadata when use UploadFile method.
+
+Documentation & Demo:
+
+Resolved Issues:
+
+-----------------------------------------------------------------------------------
+
+Version 3.25.3
+
+New Features:
+1. Added BPA feature.
+2. Added intelligent tiering feature.
+
+Documentation & Demo:
+1. Added descriptions about BPA APIs.
+
+Resolved Issues:
+
+-----------------------------------------------------------------------------------
+
+Version 3.24.9
+
+New Features:
+1. Added list POSIX Object API.
+
+Documentation & Demo:
+
+Resolved Issues:
+1. Optimize error log printing.
+
+-----------------------------------------------------------------------------------
+
+Version 3.24.6
+
+New Features:
+1. Supports passing metadata when use CopyObject and InitiateMultipartUpload method.
+
+Documentation & Demo:
+
+Resolved Issues:
+1. Fixed the issue where bucket acl configuration failed in some scenarios.
+2. Fixed the issue where data transmission exception in retry scenarios.
+
+-----------------------------------------------------------------------------------
+
+Version 3.24.3
+
+New Features:
+1. Added directory accesslable-related APIs, including SetDirAccesslabel, GetDirAccesslabel, and DeleteDirAccesslabel.
+
+Documentation & Demo:
+1. Added descriptions about directory accesslable-related APIs.
+
+Resolved Issues:
+
+-----------------------------------------------------------------------------------
+
 Version 3.23.12
 
 New Features:

--- a/openstack/obs/README.MD
+++ b/openstack/obs/README.MD
@@ -2,7 +2,7 @@
 
 ## Version
 
-3.23.12
+3.26.3
 
 ## How to change local obs sdk
 - Try to submit pull request to the official repository：

--- a/openstack/obs/client_bucket.go
+++ b/openstack/obs/client_bucket.go
@@ -600,6 +600,45 @@ func (obsClient ObsClient) DeleteBucketEncryption(bucketName string, extensions 
 	return
 }
 
+// SetBucketReplication sets the cross-region replication for a bucket.
+//
+// You can use this API to create or update the cross-region replication for a bucket.
+func (obsClient ObsClient) SetBucketReplication(input *SetBucketReplicationInput, extensions ...extensionOptions) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetBucketReplicationInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("SetBucketReplication", HTTP_PUT, input.Bucket, input, output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// GetBucketReplication gets the cross-region replication configuration of a bucket.
+//
+// You can use this API to obtain the cross-region replication configuration of a bucket.
+func (obsClient ObsClient) GetBucketReplication(bucketName string, extensions ...extensionOptions) (output *GetBucketReplicationOutput, err error) {
+	output = &GetBucketReplicationOutput{}
+	err = obsClient.doActionWithBucket("GetBucketReplication", HTTP_GET, bucketName, newSubResourceSerial(SubResourceReplication), output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// DeleteBucketReplication deletes the cross-region replication configuration of a bucket.
+//
+// You can use this API to delete the cross-region replication configuration of a bucket.
+func (obsClient ObsClient) DeleteBucketReplication(bucketName string, extensions ...extensionOptions) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketReplication", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourceReplication), output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
 // SetBucketTagging sets bucket tags.
 //
 // You can use this API to set bucket tags.

--- a/openstack/obs/client_bucket.go
+++ b/openstack/obs/client_bucket.go
@@ -37,15 +37,15 @@ func (obsClient ObsClient) SetBucketCustomDomain(input *SetBucketCustomDomainInp
 	}
 
 	output = &BaseModel{}
-	err = obsClient.doActionWithBucket("SetBucketCustomDomain", HTTP_PUT, input.Bucket, newSubResourceSerialV2(SubResourceCustomDomain, input.CustomDomain), output, extensions)
+	err = obsClient.doActionWithBucket("SetBucketCustomDomain", HTTP_PUT, input.Bucket, input, output, extensions)
 	if err != nil {
 		output = nil
 	}
 	return
 }
 
-func (obsClient ObsClient) GetBucketCustomDomain(bucketName string, extensions ...extensionOptions) (output *GetBucketCustomDomainOuput, err error) {
-	output = &GetBucketCustomDomainOuput{}
+func (obsClient ObsClient) GetBucketCustomDomain(bucketName string, extensions ...extensionOptions) (output *GetBucketCustomDomainOutput, err error) {
+	output = &GetBucketCustomDomainOutput{}
 	err = obsClient.doActionWithBucket("GetBucketCustomDomain", HTTP_GET, bucketName, newSubResourceSerial(SubResourceCustomDomain), output, extensions)
 	if err != nil {
 		output = nil
@@ -72,8 +72,8 @@ func (obsClient ObsClient) DeleteBucketMirrorBackToSource(bucketName string, ext
 	return
 }
 
-func (obsClient ObsClient) GetBucketMirrorBackToSource(bucketName string, extensions ...extensionOptions) (output *GetBucketMirrorBackToSourceOuput, err error) {
-	output = &GetBucketMirrorBackToSourceOuput{}
+func (obsClient ObsClient) GetBucketMirrorBackToSource(bucketName string, extensions ...extensionOptions) (output *GetBucketMirrorBackToSourceOutput, err error) {
+	output = &GetBucketMirrorBackToSourceOutput{}
 	err = obsClient.doActionWithBucketV2("GetBucketMirrorBackToSource", HTTP_GET, bucketName, newSubResourceSerial(SubResourceMirrorBackToSource), output, extensions)
 	if err != nil {
 		output = nil
@@ -99,14 +99,16 @@ func (obsClient ObsClient) ListBuckets(input *ListBucketsInput, extensions ...ex
 // CreateBucket creates a bucket.
 //
 // You can use this API to create a bucket and name it as you specify. The created bucket name must be unique in OBS.
-func (obsClient ObsClient) CreateBucket(input *CreateBucketInput, extensions ...extensionOptions) (output *BaseModel, err error) {
+func (obsClient ObsClient) CreateBucket(input *CreateBucketInput, extensions ...extensionOptions) (output *CreateBucketOutput, err error) {
 	if input == nil {
 		return nil, errors.New("CreateBucketInput is nil")
 	}
-	output = &BaseModel{}
+	output = &CreateBucketOutput{}
 	err = obsClient.doActionWithBucket("CreateBucket", HTTP_PUT, input.Bucket, input, output, extensions)
 	if err != nil {
 		output = nil
+	} else {
+		ParseCreateBucketOutput(output)
 	}
 	return
 }
@@ -323,8 +325,9 @@ func (obsClient ObsClient) getBucketACLObs(bucketName string, extensions []exten
 			tempOutput.Grantee.DisplayName = valGrant.Grantee.DisplayName
 			tempOutput.Grantee.ID = valGrant.Grantee.ID
 			tempOutput.Grantee.Type = valGrant.Grantee.Type
-			tempOutput.Grantee.URI = GroupAllUsers
-
+			if valGrant.Grantee.Canned == "Everyone" {
+				tempOutput.Grantee.URI = GroupAllUsers
+			}
 			output.Grants = append(output.Grants, tempOutput)
 		}
 	}
@@ -597,45 +600,6 @@ func (obsClient ObsClient) DeleteBucketEncryption(bucketName string, extensions 
 	return
 }
 
-// SetBucketReplication sets the cross-region replication for a bucket.
-//
-// You can use this API to create or update the cross-region replication for a bucket.
-func (obsClient ObsClient) SetBucketReplication(input *SetBucketReplicationInput, extensions ...extensionOptions) (output *BaseModel, err error) {
-	if input == nil {
-		return nil, errors.New("SetBucketReplicationInput is nil")
-	}
-	output = &BaseModel{}
-	err = obsClient.doActionWithBucket("SetBucketReplication", HTTP_PUT, input.Bucket, input, output, extensions)
-	if err != nil {
-		output = nil
-	}
-	return
-}
-
-// GetBucketReplication gets the cross-region replication configuration of a bucket.
-//
-// You can use this API to obtain the cross-region replication configuration of a bucket.
-func (obsClient ObsClient) GetBucketReplication(bucketName string, extensions ...extensionOptions) (output *GetBucketReplicationOutput, err error) {
-	output = &GetBucketReplicationOutput{}
-	err = obsClient.doActionWithBucket("GetBucketReplication", HTTP_GET, bucketName, newSubResourceSerial(SubResourceReplication), output, extensions)
-	if err != nil {
-		output = nil
-	}
-	return
-}
-
-// DeleteBucketReplication deletes the cross-region replication configuration of a bucket.
-//
-// You can use this API to delete the cross-region replication configuration of a bucket.
-func (obsClient ObsClient) DeleteBucketReplication(bucketName string, extensions ...extensionOptions) (output *BaseModel, err error) {
-	output = &BaseModel{}
-	err = obsClient.doActionWithBucket("DeleteBucketReplication", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourceReplication), output, extensions)
-	if err != nil {
-		output = nil
-	}
-	return
-}
-
 // SetBucketTagging sets bucket tags.
 //
 // You can use this API to set bucket tags.
@@ -837,6 +801,69 @@ func (obsClient ObsClient) GetBucketFetchJob(input *GetBucketFetchJobInput, exte
 	}
 	output = &GetBucketFetchJobOutput{}
 	err = obsClient.doActionWithBucketAndKeyV2("GetBucketFetchJob", HTTP_GET, input.Bucket, string(objectKeyAsyncFetchJob)+"/"+input.JobID, input, output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// PutBucketPublicAccessBlock sets the bucket Block Public Access.
+//
+// You can use this API to set a bucket Block Public Access.
+func (obsClient ObsClient) PutBucketPublicAccessBlock(input *PutBucketPublicAccessBlockInput, extensions ...extensionOptions) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("PutBucketPublicAccessBlockInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("PutBucketPublicAccessBlock", HTTP_PUT, input.Bucket, input, output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// GetBucketPublicAccessBlock gets the bucket Block Public Access.
+//
+// You can use this API to get a bucket Block Public Access.
+func (obsClient ObsClient) GetBucketPublicAccessBlock(bucketName string, extensions ...extensionOptions) (output *GetBucketPublicAccessBlockOutput, err error) {
+	output = &GetBucketPublicAccessBlockOutput{}
+	err = obsClient.doActionWithBucket("GetBucketPublicAccessBlock", HTTP_GET, bucketName, newSubResourceSerial(SubResourcePublicAccessBlock), output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// DeleteBucketPublicAccessBlock deletes the bucket Block Public Access.
+//
+// You can use this API to delete the Block Public Access of a bucket.
+func (obsClient ObsClient) DeleteBucketPublicAccessBlock(bucketName string, extensions ...extensionOptions) (output *BaseModel, err error) {
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucket("DeleteBucketPublicAccessBlock", HTTP_DELETE, bucketName, newSubResourceSerial(SubResourcePublicAccessBlock), output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// GetBucketPolicyPublicStatus get the bucket Policy status.
+//
+// You can use this API to get a bucket Policy status.
+func (obsClient ObsClient) GetBucketPolicyPublicStatus(bucketName string, extensions ...extensionOptions) (output *GetBucketPolicyPublicStatusOutput, err error) {
+	output = &GetBucketPolicyPublicStatusOutput{}
+	err = obsClient.doActionWithBucket("GetBucketPolicyPublicStatus", HTTP_GET, bucketName, newSubResourceSerial(SubResourceBucketPolicyPublicStatus), output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+// GetBucketPublicStatus get the bucket public status.
+//
+// You can use this API to get a bucket public status.
+func (obsClient ObsClient) GetBucketPublicStatus(bucketName string, extensions ...extensionOptions) (output *GetBucketPublicStatusOutput, err error) {
+	output = &GetBucketPublicStatusOutput{}
+	err = obsClient.doActionWithBucket("GetBucketPublicStatus", HTTP_GET, bucketName, newSubResourceSerial(SubResourceBucketPublicStatus), output, extensions)
 	if err != nil {
 		output = nil
 	}

--- a/openstack/obs/client_object.go
+++ b/openstack/obs/client_object.go
@@ -46,6 +46,32 @@ func (obsClient ObsClient) ListObjects(input *ListObjectsInput, extensions ...ex
 	return
 }
 
+// ListPosixObjects lists objects in a posix.
+//
+// You can use this API to list objects in a posix. By default, a maximum of 1000 objects are listed.
+func (obsClient ObsClient) ListPosixObjects(input *ListPosixObjectsInput, extensions ...extensionOptions) (output *ListPosixObjectsOutput, err error) {
+	if input == nil {
+		return nil, errors.New("ListPosixObjects is nil")
+	}
+	output = &ListPosixObjectsOutput{}
+	err = obsClient.doActionWithBucket("ListPosixObjects", HTTP_GET, input.Bucket, input, output, extensions)
+	if err != nil {
+		output = nil
+	} else {
+		if location, ok := output.ResponseHeaders[HEADER_BUCKET_REGION]; ok {
+			output.Location = location[0]
+		}
+		if output.EncodingType == "url" {
+			err = decodeListPosixObjectsOutput(output)
+			if err != nil {
+				doLog(LEVEL_ERROR, "Failed to get ListPosixObjectsOutput with error: %v.", err)
+				output = nil
+			}
+		}
+	}
+	return
+}
+
 // ListVersions lists versioning objects in a bucket.
 //
 // You can use this API to list versioning objects in a bucket. By default, a maximum of 1000 versioning objects are listed.
@@ -97,6 +123,52 @@ func (obsClient ObsClient) SetObjectMetadata(input *SetObjectMetadataInput, exte
 		ParseSetObjectMetadataOutput(output)
 	}
 	return
+}
+
+// GetObjectTagging gets object tags
+func (obsClient ObsClient) GetObjectTagging(input *GetObjectTaggingInput, extensions ...extensionOptions) (output *GetObjectTaggingOutput, err error) {
+	if input == nil {
+		return nil, errors.New("GetObjectTaggingInput is nil")
+	}
+	output = &GetObjectTaggingOutput{}
+	err = obsClient.doActionWithBucketAndKey("GetObjectTagging", HTTP_GET, input.Bucket, input.Key, input, output, extensions)
+	if err != nil {
+		return nil, err
+	}
+	updateVersionId(&output.ObjectTaggingOutput)
+	return output, nil
+}
+
+// SetObjectTagging sets object tags
+func (obsClient ObsClient) SetObjectTagging(input *SetObjectTaggingInput, extensions ...extensionOptions) (output *SetObjectTaggingOutput, err error) {
+	if input == nil {
+		return nil, errors.New("SetObjectTaggingInput is nil")
+	}
+
+	output = &SetObjectTaggingOutput{}
+	err = obsClient.doActionWithBucketAndKey("SetObjectTagging", HTTP_PUT, input.Bucket, input.Key, input, output, extensions)
+	if err != nil {
+		return nil, err
+	}
+
+	updateVersionId(&output.ObjectTaggingOutput)
+	return output, nil
+}
+
+// DeleteObjectTagging deletes object tags
+func (obsClient ObsClient) DeleteObjectTagging(input *DeleteObjectTaggingInput, extensions ...extensionOptions) (output *DeleteObjectTaggingOutput, err error) {
+	if input == nil {
+		return nil, errors.New("DeleteObjectTaggingInput is nil")
+	}
+
+	output = &DeleteObjectTaggingOutput{}
+	err = obsClient.doActionWithBucketAndKey("DeleteObjectTagging", HTTP_DELETE, input.Bucket, input.Key, input, output, extensions)
+	if err != nil {
+		return nil, err
+	}
+
+	updateVersionId(&output.ObjectTaggingOutput)
+	return output, nil
 }
 
 // DeleteObject deletes an object.
@@ -221,6 +293,9 @@ func (obsClient ObsClient) GetAttribute(input *GetAttributeInput, extensions ...
 func (obsClient ObsClient) GetObject(input *GetObjectInput, extensions ...extensionOptions) (output *GetObjectOutput, err error) {
 	if input == nil {
 		return nil, errors.New("GetObjectInput is nil")
+	}
+	if input.Range != "" && !strings.HasPrefix(input.Range, "bytes=") {
+		return nil, errors.New("Range should start with [bytes=]")
 	}
 	output = &GetObjectOutput{}
 	err = obsClient.doActionWithBucketAndKeyWithProgress(GET_OBJECT, HTTP_GET, input.Bucket, input.Key, input, output, extensions, nil)
@@ -499,6 +574,42 @@ func (obsClient ObsClient) RenameFolder(input *RenameFolderInput, extensions ...
 	}
 	output = &RenameFolderOutput{}
 	err = obsClient.doActionWithBucketAndKey("RenameFolder", HTTP_POST, input.Bucket, input.Key, input, output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) SetDirAccesslabel(input *SetDirAccesslabelInput, extensions ...extensionOptions) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("SetDirAccesslabelInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucketAndKeyV2("SetDirAccesslabel", HTTP_PUT, input.Bucket, input.Key, input, output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) GetDirAccesslabel(input *GetDirAccesslabelInput, extensions ...extensionOptions) (output *GetDirAccesslabelOutput, err error) {
+	if input == nil {
+		return nil, errors.New("GetDirAccesslabelInput is nil")
+	}
+	output = &GetDirAccesslabelOutput{}
+	err = obsClient.doActionWithBucketAndKeyV2("GetDirAccesslabel", HTTP_GET, input.Bucket, input.Key, input, output, extensions)
+	if err != nil {
+		output = nil
+	}
+	return
+}
+
+func (obsClient ObsClient) DeleteDirAccesslabel(input *DeleteDirAccesslabelInput, extensions ...extensionOptions) (output *BaseModel, err error) {
+	if input == nil {
+		return nil, errors.New("DeleteDirAccesslabelInput is nil")
+	}
+	output = &BaseModel{}
+	err = obsClient.doActionWithBucketAndKeyV2("DeleteDirAccesslabel", HTTP_DELETE, input.Bucket, input.Key, input, output, extensions)
 	if err != nil {
 		output = nil
 	}

--- a/openstack/obs/client_part.go
+++ b/openstack/obs/client_part.go
@@ -106,6 +106,7 @@ func (obsClient ObsClient) UploadPart(_input *UploadPartInput, extensions ...ext
 	input.PartNumber = _input.PartNumber
 	input.UploadId = _input.UploadId
 	input.ContentMD5 = _input.ContentMD5
+	input.ContentSHA256 = _input.ContentSHA256
 	input.SourceFile = _input.SourceFile
 	input.Offset = _input.Offset
 	input.PartSize = _input.PartSize
@@ -151,6 +152,7 @@ func (obsClient ObsClient) UploadPart(_input *UploadPartInput, extensions ...ext
 			input.PartSize = fileSize - input.Offset
 		}
 		fileReaderWrapper.totalCount = input.PartSize
+		fileReaderWrapper.mark = input.Offset
 		if _, err = fd.Seek(input.Offset, io.SeekStart); err != nil {
 			return nil, err
 		}
@@ -238,6 +240,9 @@ func (obsClient ObsClient) CopyPart(input *CopyPartInput, extensions ...extensio
 	}
 	if strings.TrimSpace(input.CopySourceKey) == "" {
 		return nil, errors.New("Source key is empty")
+	}
+	if input.CopySourceRange != "" && !strings.HasPrefix(input.CopySourceRange, "bytes=") {
+		return nil, errors.New("Source Range should start with [bytes=]")
 	}
 
 	output = &CopyPartOutput{}

--- a/openstack/obs/conf.go
+++ b/openstack/obs/conf.go
@@ -70,7 +70,7 @@ type config struct {
 	customProxyFuncValue func(*url.URL) (*url.URL, error)
 }
 
-func (conf config) String() string {
+func (conf *config) String() string {
 	return fmt.Sprintf("[endpoint:%s, signature:%s, pathStyle:%v, region:%s,"+
 		"\nconnectTimeout:%d, socketTimeout:%d, headerTimeout:%d, idleConnTimeout:%d,"+
 		"\nmaxRetryCount:%d, maxConnsPerHost:%d, sslVerify:%v, maxRedirectCount:%d,"+

--- a/openstack/obs/conf.go
+++ b/openstack/obs/conf.go
@@ -70,13 +70,15 @@ type config struct {
 	customProxyFuncValue func(*url.URL) (*url.URL, error)
 }
 
-func (conf *config) String() string {
-	return fmt.Sprintf("[endpoint:%s, signature:%s, pathStyle:%v, region:%s"+
-		"\nconnectTimeout:%d, socketTimeout:%dheaderTimeout:%d, idleConnTimeout:%d"+
-		"\nmaxRetryCount:%d, maxConnsPerHost:%d, sslVerify:%v, maxRedirectCount:%d]",
+func (conf config) String() string {
+	return fmt.Sprintf("[endpoint:%s, signature:%s, pathStyle:%v, region:%s,"+
+		"\nconnectTimeout:%d, socketTimeout:%d, headerTimeout:%d, idleConnTimeout:%d,"+
+		"\nmaxRetryCount:%d, maxConnsPerHost:%d, sslVerify:%v, maxRedirectCount:%d,"+
+		"\ncname:%v, userAgent:%s, disableKeepAlive:%v, proxyFromEnv:%v]",
 		conf.endpoint, conf.signature, conf.pathStyle, conf.region,
 		conf.connectTimeout, conf.socketTimeout, conf.headerTimeout, conf.idleConnTimeout,
 		conf.maxRetryCount, conf.maxConnsPerHost, conf.sslVerify, conf.maxRedirectCount,
+		conf.cname, conf.userAgent, conf.disableKeepAlive, conf.proxyFromEnv,
 	)
 }
 

--- a/openstack/obs/const.go
+++ b/openstack/obs/const.go
@@ -13,7 +13,7 @@
 package obs
 
 const (
-	OBS_SDK_VERSION        = "3.23.12"
+	OBS_SDK_VERSION        = "3.26.3"
 	USER_AGENT             = "obs-sdk-go/" + OBS_SDK_VERSION
 	HEADER_PREFIX          = "x-amz-"
 	HEADER_PREFIX_META     = "x-amz-meta-"
@@ -50,6 +50,7 @@ const (
 	HEADER_GRANT_FULL_CONTROL_DELIVERED_OBS = "grant-full-control-delivered"
 	HEADER_REQUEST_ID                       = "request-id"
 	HEADER_ERROR_CODE                       = "error-code"
+	HEADER_ERROR_INDICATOR                  = "x-reserved-indicator"
 	HEADER_ERROR_MESSAGE                    = "error-message"
 	HEADER_BUCKET_REGION                    = "bucket-region"
 	HEADER_ACCESS_CONRTOL_ALLOW_ORIGIN      = "access-control-allow-origin"
@@ -100,9 +101,13 @@ const (
 	HEADER_SSEC_KEY        = "server-side-encryption-customer-key"
 	HEADER_SSEC_KEY_MD5    = "server-side-encryption-customer-key-MD5"
 
-	HEADER_SSEKMS_ENCRYPTION      = "server-side-encryption"
-	HEADER_SSEKMS_KEY             = "server-side-encryption-aws-kms-key-id"
-	HEADER_SSEKMS_ENCRYPT_KEY_OBS = "server-side-encryption-kms-key-id"
+	HEADER_SSEKMS_ENCRYPTION                         = "server-side-encryption"
+	HEADER_SSEKMS_DATA_ENCRYPTION                    = "server-side-data-encryption"
+	HEADER_SSEKMS_KEY                                = "server-side-encryption-aws-kms-key-id"
+	HEADER_SSEKMS_ENCRYPT_KEY_OBS                    = "server-side-encryption-kms-key-id"
+	HEADER_SSEKMS_KEY_PROJECT                        = "sse-kms-key-project-id"
+	HEADER_SSEKMS_ENCRYPT_BUCKET_KEY_ENABLED         = "server-side-encryption-bucket-key-enabled"
+	HEADER_SSEKMS_ENCRYPT_BUCKET_KEY_ROTATION_PERIOD = "server-side-encryption-bucket-key-rotation-period"
 
 	HEADER_SSEC_COPY_SOURCE_ENCRYPTION = "copy-source-server-side-encryption-customer-algorithm"
 	HEADER_SSEC_COPY_SOURCE_KEY        = "copy-source-server-side-encryption-customer-key"
@@ -117,10 +122,13 @@ const (
 	headerFSFileInterface = "fs-file-interface"
 
 	HEADER_DATE_CAMEL                          = "Date"
+	HEADER_DATE                                = "date"
 	HEADER_HOST_CAMEL                          = "Host"
 	HEADER_HOST                                = "host"
 	HEADER_AUTH_CAMEL                          = "Authorization"
 	HEADER_MD5_CAMEL                           = "Content-MD5"
+	HEADER_SHA256_CAMEL                        = "Content-SHA256"
+	HEADER_SHA256                              = "content-sha256"
 	HEADER_LOCATION_CAMEL                      = "Location"
 	HEADER_CONTENT_LENGTH_CAMEL                = "Content-Length"
 	HEADER_CONTENT_TYPE_CAML                   = "Content-Type"
@@ -197,11 +205,19 @@ const (
 	MIN_PART_SIZE     = 100 * 1024
 	DEFAULT_PART_SIZE = 9 * 1024 * 1024
 	MAX_PART_NUM      = 10000
+	MAX_LOG_SIZE      = 1000
 
-	GET_OBJECT    = "GetObject"
-	PUT_OBJECT    = "PutObject"
-	PUT_FILE      = "PutFile"
-	APPEND_OBJECT = "AppendObject"
+	GET_OBJECT                  = "GetObject"
+	PUT_OBJECT                  = "PutObject"
+	PUT_FILE                    = "PutFile"
+	APPEND_OBJECT               = "AppendObject"
+	MAX_CERT_XML_BODY_SIZE      = 40 * 1024
+	CERT_ID_SIZE                = 16
+	MAX_CERTIFICATE_NAME_LENGTH = 63
+	MIN_CERTIFICATE_NAME_LENGTH = 3
+	CERTIFICATE_FIELD_NAME      = "CERTIFICATE ID SIZE"
+	NAME_LENGTH                 = "Name Length"
+	XML_SIZE                    = "XML SIZE"
 )
 
 var (
@@ -210,6 +226,7 @@ var (
 	allowedRequestHTTPHeaderMetadataNames = map[string]bool{
 		"content-type":                   true,
 		"content-md5":                    true,
+		"content-sha256":                 true,
 		"content-length":                 true,
 		"content-language":               true,
 		"expires":                        true,
@@ -232,15 +249,18 @@ var (
 		"last-modified":                  true,
 		"content-range":                  true,
 		"accept-encoding":                true,
+		"x-hic-info":                     true,
+		"safe-area":                      true,
 	}
 
 	allowedLogResponseHTTPHeaderNames = map[string]bool{
-		"content-type":   true,
-		"etag":           true,
-		"connection":     true,
-		"content-length": true,
-		"date":           true,
-		"server":         true,
+		"content-type":         true,
+		"etag":                 true,
+		"connection":           true,
+		"content-length":       true,
+		"date":                 true,
+		"server":               true,
+		"x-reserved-indicator": true,
 	}
 
 	allowedResourceParameterNames = map[string]bool{
@@ -290,6 +310,19 @@ var (
 		"rename":                       true,
 		"customdomain":                 true,
 		"mirrorbacktosource":           true,
+		"x-obs-accesslabel":            true,
+		"object-lock":                  true,
+		"retention":                    true,
+		"x-obs-security-token":         true,
+		"truncate":                     true,
+		"length":                       true,
+		"inventory":                    true,
+		"directcoldaccess":             true,
+		"attname":                      true,
+		"cdnnotifyconfiguration":       true,
+		"publicaccessblock":            true,
+		"bucketstatus":                 true,
+		"policystatus":                 true,
 	}
 
 	obsStorageClasses = []string{
@@ -297,5 +330,6 @@ var (
 		string(StorageClassWarm),
 		string(StorageClassCold),
 		string(StorageClassDeepArchive),
+		string(StorageClassIntelligentTiering),
 	}
 )

--- a/openstack/obs/convert.go
+++ b/openstack/obs/convert.go
@@ -15,6 +15,7 @@ package obs
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -27,11 +28,16 @@ import (
 	"time"
 )
 
-func cleanHeaderPrefix(header http.Header) map[string][]string {
+func cleanHeaderPrefix(header http.Header, isObs bool) map[string][]string {
 	responseHeaders := make(map[string][]string)
 	for key, value := range header {
 		if len(value) > 0 {
 			key = strings.ToLower(key)
+
+			if !isObs && strings.HasSuffix(key, HEADER_EXPIRES_OBS) {
+				responseHeaders[key] = value
+				continue
+			}
 			if strings.HasPrefix(key, HEADER_PREFIX) || strings.HasPrefix(key, HEADER_PREFIX_OBS) {
 				key = key[len(HEADER_PREFIX):]
 			}
@@ -77,6 +83,8 @@ func ParseStringToStorageClassType(value string) (ret StorageClassType) {
 		ret = StorageClassCold
 	case string(StorageClassDeepArchive):
 		ret = StorageClassDeepArchive
+	case string(StorageClassIntelligentTiering):
+		ret = StorageClassIntelligentTiering
 	default:
 		ret = ""
 	}
@@ -95,18 +103,30 @@ func ParseStringToFSStatusType(value string) (ret FSStatusType) {
 	return
 }
 
-func prepareGrantURI(grant Grant) string {
-	if grant.Grantee.URI == GroupAllUsers || grant.Grantee.URI == GroupAuthenticatedUsers {
-		return fmt.Sprintf("<URI>%s%s</URI>", "http://acs.amazonaws.com/groups/global/", grant.Grantee.URI)
+func prepareGrantURI(grantUri GroupUriType) string {
+	if grantUri == GroupAllUsers || grantUri == GroupAuthenticatedUsers {
+		return fmt.Sprintf("<URI>%s%s</URI>", "http://acs.amazonaws.com/groups/global/", grantUri)
 	}
-	if grant.Grantee.URI == GroupLogDelivery {
-		return fmt.Sprintf("<URI>%s%s</URI>", "http://acs.amazonaws.com/groups/s3/", grant.Grantee.URI)
+	if grantUri == GroupLogDelivery {
+		return fmt.Sprintf("<URI>%s%s</URI>", "http://acs.amazonaws.com/groups/s3/", grantUri)
 	}
-	return fmt.Sprintf("<URI>%s</URI>", grant.Grantee.URI)
+	return fmt.Sprintf("<URI>%s</URI>", grantUri)
 }
 
 func convertGrantToXML(grant Grant, isObs bool, isBucket bool) string {
 	xml := make([]string, 0, 4)
+
+	if grant.Grantee.ID != "" &&
+		grant.Grantee.URI == "" &&
+		grant.Grantee.Type == "" {
+		grant.Grantee.Type = GranteeUser
+	}
+
+	if grant.Grantee.URI != "" &&
+		grant.Grantee.ID == "" &&
+		grant.Grantee.Type == "" {
+		grant.Grantee.Type = GranteeGroup
+	}
 
 	if grant.Grantee.Type == GranteeUser {
 		if isObs {
@@ -126,7 +146,7 @@ func convertGrantToXML(grant Grant, isObs bool, isBucket bool) string {
 	} else {
 		if !isObs {
 			xml = append(xml, fmt.Sprintf("<Grant><Grantee xsi:type=\"%s\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">", grant.Grantee.Type))
-			xml = append(xml, prepareGrantURI(grant))
+			xml = append(xml, prepareGrantURI(grant.Grantee.URI))
 			xml = append(xml, "</Grantee>")
 		} else if grant.Grantee.URI == GroupAllUsers {
 			xml = append(xml, "<Grant><Grantee>")
@@ -157,7 +177,11 @@ func ConvertLoggingStatusToXml(input BucketLoggingStatus, returnMd5 bool, isObs 
 	grantsLength := len(input.TargetGrants)
 	xml := make([]string, 0, 8+grantsLength)
 
-	xml = append(xml, "<BucketLoggingStatus>")
+	if isObs {
+		xml = append(xml, "<BucketLoggingStatus>")
+	} else {
+		xml = append(xml, `<BucketLoggingStatus xmlns="http://s3.amazonaws.com/doc/2006-03-01/">`)
+	}
 	if isObs && input.Agency != "" {
 		agency := XmlTranscoding(input.Agency)
 		xml = append(xml, fmt.Sprintf("<Agency>%s</Agency>", agency))
@@ -186,6 +210,28 @@ func ConvertLoggingStatusToXml(input BucketLoggingStatus, returnMd5 bool, isObs 
 	if returnMd5 {
 		md5 = Base64Md5([]byte(data))
 	}
+	return
+}
+
+func ConvertObjectTagsToXml(input []Tag, returnMd5 bool) (data string, md5 string, err error) {
+	if len(input) == 0 {
+		err = fmt.Errorf("no tags provided")
+		return
+	}
+	tagging := Tagging{
+		Tags: input,
+	}
+
+	out, e := xml.Marshal(tagging)
+	if e != nil {
+		err = fmt.Errorf("failed to marshal xml: %w", e)
+		return
+	}
+
+	if returnMd5 {
+		md5 = Base64Md5(out)
+	}
+	data = string(out)
 	return
 }
 
@@ -409,7 +455,7 @@ func convertAbortIncompleteMultipartUploadToXML(abortIncompleteMultipartUpload A
 }
 
 // ConvertLifecycleConfigurationToXml converts BucketLifecycleConfiguration value to XML data and returns it
-func ConvertLifecycleConfigurationToXml(input BucketLifecycleConfiguration, returnMd5 bool, isObs bool) (data string, md5 string) {
+func ConvertLifecycleConfigurationToXml(input BucketLifecycleConfiguration, returnMd5, isObs, enableSha256 bool) (data string, md5OrSha256 string) {
 	xml := make([]string, 0, 2+len(input.LifecycleRules)*9)
 	xml = append(xml, "<LifecycleConfiguration>")
 	for _, lifecycleRule := range input.LifecycleRules {
@@ -447,7 +493,7 @@ func ConvertLifecycleConfigurationToXml(input BucketLifecycleConfiguration, retu
 	xml = append(xml, "</LifecycleConfiguration>")
 	data = strings.Join(xml, "")
 	if returnMd5 {
-		md5 = Base64Md5([]byte(data))
+		md5OrSha256 = Base64Md5OrSha256([]byte(data), enableSha256)
 	}
 	return
 }
@@ -464,59 +510,26 @@ func ConvertEncryptionConfigurationToXml(input BucketEncryptionConfiguration, re
 		kmsKeyID := XmlTranscoding(input.KMSMasterKeyID)
 		xml = append(xml, fmt.Sprintf("<KMSMasterKeyID>%s</KMSMasterKeyID>", kmsKeyID))
 	}
+	if input.KMSDataEncryption != "" {
+		kmsKeyID := XmlTranscoding(input.KMSDataEncryption)
+		xml = append(xml, fmt.Sprintf("<KMSDataEncryption>%s</KMSDataEncryption>", kmsKeyID))
+	}
 	if input.ProjectID != "" {
 		projectID := XmlTranscoding(input.ProjectID)
 		xml = append(xml, fmt.Sprintf("<ProjectID>%s</ProjectID>", projectID))
 	}
 
-	xml = append(xml, "</ApplyServerSideEncryptionByDefault></Rule></ServerSideEncryptionConfiguration>")
-	data = strings.Join(xml, "")
-	if returnMd5 {
-		md5 = Base64Md5([]byte(data))
+	xml = append(xml, "</ApplyServerSideEncryptionByDefault>")
+
+	if input.BucketKeyEnabled {
+		xml = append(xml, fmt.Sprintf("<BucketKeyEnabled>%v</BucketKeyEnabled>", input.BucketKeyEnabled))
 	}
-	return
-}
-
-// convertReplicationConfigurationToXml converts BucketReplicationConfiguration value to XML data and returns it
-func convertReplicationConfigurationToXml(input BucketReplicationConfiguration, returnMd5 bool, isObs bool) (data string, md5 string) {
-	xml := make([]string, 0, 3+len(input.ReplicationRules)*6)
-
-	xml = append(xml, "<ReplicationConfiguration>")
-	xml = append(xml, fmt.Sprintf("<Agency>%s</Agency>", XmlTranscoding(input.Agency)))
-
-	for _, rule := range input.ReplicationRules {
-		xml = append(xml, "<Rule>")
-		xml = append(xml, fmt.Sprintf("<Status>%s</Status>", rule.Status))
-		xml = append(xml, fmt.Sprintf("<Prefix>%s</Prefix>", XmlTranscoding(rule.Prefix)))
-
-		xml = append(xml, fmt.Sprintf("<Destination><Bucket>%s</Bucket>", XmlTranscoding(rule.DestinationBucket)))
-		if rule.StorageClass != "" {
-			storageClass := string(rule.StorageClass)
-			if !isObs {
-				if storageClass == string(StorageClassWarm) {
-					storageClass = string(storageClassStandardIA)
-				} else if storageClass == string(StorageClassCold) {
-					storageClass = string(storageClassGlacier)
-				}
-			}
-			xml = append(xml, fmt.Sprintf("<StorageClass>%s</StorageClass>", storageClass))
-		}
-		if rule.DeleteDate != "" {
-			xml = append(xml, fmt.Sprintf("<DeleteDate>%s</DeleteDate>", rule.DeleteDate))
-		}
-		xml = append(xml, "</Destination>")
-
-		if rule.ID != "" {
-			xml = append(xml, fmt.Sprintf("<ID>%s</ID>", XmlTranscoding(rule.ID)))
-		}
-
-		if rule.HistoricalObjectReplication != "" {
-			xml = append(xml, fmt.Sprintf("<HistoricalObjectReplication>%s</HistoricalObjectReplication>",
-				rule.HistoricalObjectReplication))
-		}
-		xml = append(xml, "</Rule>")
+	if input.BucketKeyRotationPeriod != 0 {
+		xml = append(xml, fmt.Sprintf("<BucketKeyRotationPeriod>%d</BucketKeyRotationPeriod>", input.BucketKeyRotationPeriod))
 	}
-	xml = append(xml, "</ReplicationConfiguration>")
+
+	xml = append(xml, "</Rule></ServerSideEncryptionConfiguration>")
+
 	data = strings.Join(xml, "")
 	if returnMd5 {
 		md5 = Base64Md5([]byte(data))
@@ -585,8 +598,8 @@ func converntConfigureToXML(topicConfiguration TopicConfiguration, xmlElem strin
 	return strings.Join(xml, "")
 }
 
-// ConverntObsRestoreToXml converts RestoreObjectInput value to XML data and returns it
-func ConverntObsRestoreToXml(restoreObjectInput RestoreObjectInput) string {
+// ConventObsRestoreToXml converts RestoreObjectInput value to XML data and returns it
+func ConventObsRestoreToXml(restoreObjectInput RestoreObjectInput) string {
 	xml := make([]string, 0, 2)
 	xml = append(xml, fmt.Sprintf("<RestoreRequest><Days>%d</Days>", restoreObjectInput.Days))
 	if restoreObjectInput.Tier != "Bulk" {
@@ -670,6 +683,21 @@ func parseSseHeader(responseHeaders map[string][]string) (sseHeader ISseHeader) 
 		} else if ret, ok = responseHeaders[HEADER_SSEKMS_ENCRYPT_KEY_OBS]; ok {
 			sseKmsHeader.Key = ret[0]
 		}
+		if ret, ok = responseHeaders[HEADER_SSEKMS_DATA_ENCRYPTION]; ok {
+			sseKmsHeader.DataEncryption = ret[0]
+		}
+		if ret, ok = responseHeaders[HEADER_SSEKMS_ENCRYPT_BUCKET_KEY_ENABLED]; ok {
+			ret, err := strconv.ParseBool(ret[0])
+			if err == nil {
+				sseKmsHeader.BucketKeyEnabled = ret
+			}
+		}
+		if ret, ok = responseHeaders[HEADER_SSEKMS_ENCRYPT_BUCKET_KEY_ROTATION_PERIOD]; ok {
+			ret, err := strconv.ParseInt(ret[0], 10, 64)
+			if err == nil {
+				sseKmsHeader.RotationPeriod = ret
+			}
+		}
 		sseHeader = sseKmsHeader
 	}
 	return
@@ -716,26 +744,24 @@ func parseUnCommonHeader(output *GetObjectMetadataOutput) {
 }
 
 func parseStandardMetadataHeader(output *GetObjectMetadataOutput) {
-	httpHeader := HttpHeader{}
 	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_TYPE]; ok {
-		httpHeader.ContentType = ret[0]
+		output.ContentType = ret[0]
 	}
 	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_ENCODING]; ok {
-		httpHeader.ContentEncoding = ret[0]
+		output.ContentEncoding = ret[0]
 	}
 	if ret, ok := output.ResponseHeaders[HEADER_CACHE_CONTROL]; ok {
-		httpHeader.CacheControl = ret[0]
+		output.CacheControl = ret[0]
 	}
 	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_DISPOSITION]; ok {
-		httpHeader.ContentDisposition = ret[0]
+		output.ContentDisposition = ret[0]
 	}
 	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_LANGUAGE]; ok {
-		httpHeader.ContentLanguage = ret[0]
+		output.ContentLanguage = ret[0]
 	}
 	if ret, ok := output.ResponseHeaders[HEADER_EXPIRES]; ok {
-		httpHeader.HttpExpires = ret[0]
+		output.HttpExpires = ret[0]
 	}
-	output.HttpHeader = httpHeader
 }
 
 // ParseGetObjectMetadataOutput sets GetObjectMetadataOutput field values with response headers
@@ -748,9 +774,6 @@ func ParseGetObjectMetadataOutput(output *GetObjectMetadataOutput) {
 	}
 	if ret, ok := output.ResponseHeaders[HEADER_ETAG]; ok {
 		output.ETag = ret[0]
-	}
-	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_TYPE]; ok {
-		output.ContentType = ret[0]
 	}
 
 	output.SseHeader = parseSseHeader(output.ResponseHeaders)
@@ -871,6 +894,21 @@ func ParseGetBucketMetadataOutput(output *GetBucketMetadataOutput) {
 	}
 }
 
+func ParseCreateBucketOutput(output *CreateBucketOutput) {
+	if ret, ok := output.ResponseHeaders[HEADER_LOCATION_AMZ]; ok {
+		output.Location = ret[0]
+	}
+
+	if ret, ok := output.ResponseHeaders[HEADER_DATE]; ok {
+		ret, err := time.Parse(time.RFC1123, ret[0])
+		if err == nil {
+			output.Date = ret
+		}
+	}
+
+	output.SseHeader = parseSseHeader(output.ResponseHeaders)
+}
+
 func parseContentHeader(output *SetObjectMetadataOutput) {
 	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_DISPOSITION]; ok {
 		output.ContentDisposition = ret[0]
@@ -935,6 +973,9 @@ func ParseGetObjectOutput(output *GetObjectOutput) {
 	if ret, ok := output.ResponseHeaders[HEADER_DELETE_MARKER]; ok {
 		output.DeleteMarker = ret[0] == "true"
 	}
+	if ret, ok := output.ResponseHeaders[HEADER_CONTENT_TYPE]; ok {
+		output.ContentType = ret[0]
+	}
 	if ret, ok := output.ResponseHeaders[HEADER_CACHE_CONTROL]; ok {
 		output.CacheControl = ret[0]
 	}
@@ -949,14 +990,16 @@ func ParseGetObjectOutput(output *GetObjectOutput) {
 	}
 	if ret, ok := output.ResponseHeaders[HEADER_EXPIRES]; ok {
 		output.Expires = ret[0]
+		output.HttpExpires = ret[0]
 	}
 }
 
 // ConvertRequestToIoReaderV2 converts req to XML data
-func ConvertRequestToIoReaderV2(req interface{}) (io.Reader, string, error) {
+func ConvertRequestToIoReaderV2(req interface{}, enableSha256 bool) (io.Reader, string, error) {
 	data, err := TransToXml(req)
+	md5OrSha256 := Base64Md5OrSha256(data, enableSha256)
 	if err == nil {
-		return bytes.NewReader(data), Base64Md5(data), nil
+		return bytes.NewReader(data), md5OrSha256, nil
 	}
 	return nil, "", err
 }
@@ -982,7 +1025,7 @@ func parseResponseBodyOutput(s reflect.Type, baseModel IBaseModel, body []byte) 
 // ParseCallbackResponseToBaseModel gets response from Callback Service
 func ParseCallbackResponseToBaseModel(resp *http.Response, baseModel IBaseModel, isObs bool) error {
 	baseModel.setStatusCode(resp.StatusCode)
-	responseHeaders := cleanHeaderPrefix(resp.Header)
+	responseHeaders := cleanHeaderPrefix(resp.Header, isObs)
 	baseModel.setResponseHeaders(responseHeaders)
 	if values, ok := responseHeaders[HEADER_REQUEST_ID]; ok {
 		baseModel.setRequestID(values[0])
@@ -1008,19 +1051,25 @@ func ParseResponseToBaseModel(resp *http.Response, baseModel IBaseModel, xmlResu
 		var body []byte
 		body, err = ioutil.ReadAll(resp.Body)
 		if err == nil && len(body) > 0 {
+			name := reflect.TypeOf(baseModel).Elem().Name()
 			if xmlResult {
 				err = ParseXml(body, baseModel)
 			} else {
 				s := reflect.TypeOf(baseModel).Elem()
-				name := reflect.TypeOf(baseModel).Elem().Name()
-				if name == "GetBucketPolicyOutput" || name == "GetBucketMirrorBackToSourceOuput" {
+				if name == "GetBucketPolicyOutput" || name == "GetBucketMirrorBackToSourceOutput" {
 					parseResponseBodyOutput(s, baseModel, body)
 				} else {
 					err = parseJSON(body, baseModel)
 				}
 			}
 			if err != nil {
-				doLog(LEVEL_ERROR, "Unmarshal error: %v", err)
+				if _, ok := baseModel.(*ObsError); !ok && (name == "CopyObjectOutput" || name == "CopyPartOutput") {
+					doLog(LEVEL_ERROR, "Unmarshal error: %v, try parse response to ObsError", err)
+					err = ParseErrorBodyToObsError(body, resp, xmlResult, isObs)
+					return err
+				} else {
+					doLog(LEVEL_ERROR, "Unmarshal error: %v", err)
+				}
 			}
 		}
 	} else {
@@ -1028,10 +1077,45 @@ func ParseResponseToBaseModel(resp *http.Response, baseModel IBaseModel, xmlResu
 	}
 
 	baseModel.setStatusCode(resp.StatusCode)
-	responseHeaders := cleanHeaderPrefix(resp.Header)
+	responseHeaders := cleanHeaderPrefix(resp.Header, isObs)
 	baseModel.setResponseHeaders(responseHeaders)
 	if values, ok := responseHeaders[HEADER_REQUEST_ID]; ok {
 		baseModel.setRequestID(values[0])
+	}
+	return
+}
+
+// ParseErrorBodyToObsError gets obsError from OBS
+func ParseErrorBodyToObsError(body []byte, resp *http.Response, xmlResult, isObs bool) (err error) {
+	obsError := ObsError{}
+	var parseErr error
+	if xmlResult {
+		parseErr = ParseXml(body, &obsError)
+	} else {
+		parseErr = parseJSON(body, &obsError)
+	}
+
+	if parseErr != nil {
+		doLog(LEVEL_ERROR, "Failed to parse ObsError from body: %v", parseErr)
+		limit := MAX_LOG_SIZE
+		if len(body) < limit {
+			limit = len(body)
+		}
+		err = fmt.Errorf("request failed, raw body: %q", body[:limit])
+	} else {
+		obsError.Status = resp.Status
+
+		obsError.setStatusCode(resp.StatusCode)
+		responseHeaders := cleanHeaderPrefix(resp.Header, isObs)
+		obsError.setResponseHeaders(responseHeaders)
+		if values, ok := responseHeaders[HEADER_REQUEST_ID]; ok {
+			obsError.setRequestID(values[0])
+		}
+		if values, ok := responseHeaders[HEADER_ERROR_INDICATOR]; ok {
+			obsError.Indicator = values[0]
+		}
+
+		err = obsError
 	}
 	return
 }
@@ -1049,12 +1133,15 @@ func ParseResponseToObsError(resp *http.Response, isObs bool) error {
 		doLog(LEVEL_WARN, "Parse response to BaseModel with error: %v", respError)
 	}
 	obsError.Status = resp.Status
-	responseHeaders := cleanHeaderPrefix(resp.Header)
+	responseHeaders := cleanHeaderPrefix(resp.Header, isObs)
 	if values, ok := responseHeaders[HEADER_ERROR_MESSAGE]; ok {
 		obsError.Message = values[0]
 	}
 	if values, ok := responseHeaders[HEADER_ERROR_CODE]; ok {
 		obsError.Code = values[0]
+	}
+	if values, ok := responseHeaders[HEADER_ERROR_INDICATOR]; ok {
+		obsError.Indicator = values[0]
 	}
 	return obsError
 }
@@ -1134,6 +1221,38 @@ func decodeListObjectsOutput(output *ListObjectsOutput) (err error) {
 	}
 	for index, value := range output.CommonPrefixes {
 		output.CommonPrefixes[index], err = url.QueryUnescape(value)
+		if err != nil {
+			return
+		}
+	}
+	for index, content := range output.Contents {
+		output.Contents[index].Key, err = url.QueryUnescape(content.Key)
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+func decodeListPosixObjectsOutput(output *ListPosixObjectsOutput) (err error) {
+	output.Delimiter, err = url.QueryUnescape(output.Delimiter)
+	if err != nil {
+		return
+	}
+	output.Marker, err = url.QueryUnescape(output.Marker)
+	if err != nil {
+		return
+	}
+	output.NextMarker, err = url.QueryUnescape(output.NextMarker)
+	if err != nil {
+		return
+	}
+	output.Prefix, err = url.QueryUnescape(output.Prefix)
+	if err != nil {
+		return
+	}
+	for index, value := range output.CommonPrefixes {
+		output.CommonPrefixes[index].Prefix, err = url.QueryUnescape(value.Prefix)
 		if err != nil {
 			return
 		}

--- a/openstack/obs/convert.go
+++ b/openstack/obs/convert.go
@@ -537,6 +537,53 @@ func ConvertEncryptionConfigurationToXml(input BucketEncryptionConfiguration, re
 	return
 }
 
+// convertReplicationConfigurationToXml converts BucketReplicationConfiguration value to XML data and returns it
+func convertReplicationConfigurationToXml(input BucketReplicationConfiguration, returnMd5 bool, isObs bool) (data string, md5 string) {
+	xml := make([]string, 0, 3+len(input.ReplicationRules)*6)
+
+	xml = append(xml, "<ReplicationConfiguration>")
+	xml = append(xml, fmt.Sprintf("<Agency>%s</Agency>", XmlTranscoding(input.Agency)))
+
+	for _, rule := range input.ReplicationRules {
+		xml = append(xml, "<Rule>")
+		xml = append(xml, fmt.Sprintf("<Status>%s</Status>", rule.Status))
+		xml = append(xml, fmt.Sprintf("<Prefix>%s</Prefix>", XmlTranscoding(rule.Prefix)))
+
+		xml = append(xml, fmt.Sprintf("<Destination><Bucket>%s</Bucket>", XmlTranscoding(rule.DestinationBucket)))
+		if rule.StorageClass != "" {
+			storageClass := string(rule.StorageClass)
+			if !isObs {
+				if storageClass == string(StorageClassWarm) {
+					storageClass = string(storageClassStandardIA)
+				} else if storageClass == string(StorageClassCold) {
+					storageClass = string(storageClassGlacier)
+				}
+			}
+			xml = append(xml, fmt.Sprintf("<StorageClass>%s</StorageClass>", storageClass))
+		}
+		if rule.DeleteDate != "" {
+			xml = append(xml, fmt.Sprintf("<DeleteDate>%s</DeleteDate>", rule.DeleteDate))
+		}
+		xml = append(xml, "</Destination>")
+
+		if rule.ID != "" {
+			xml = append(xml, fmt.Sprintf("<ID>%s</ID>", XmlTranscoding(rule.ID)))
+		}
+
+		if rule.HistoricalObjectReplication != "" {
+			xml = append(xml, fmt.Sprintf("<HistoricalObjectReplication>%s</HistoricalObjectReplication>",
+				rule.HistoricalObjectReplication))
+		}
+		xml = append(xml, "</Rule>")
+	}
+	xml = append(xml, "</ReplicationConfiguration>")
+	data = strings.Join(xml, "")
+	if returnMd5 {
+		md5 = Base64Md5([]byte(data))
+	}
+	return
+}
+
 func converntFilterRulesToXML(filterRules []FilterRule, isObs bool) string {
 	if length := len(filterRules); length > 0 {
 		xml := make([]string, 0, length*4)

--- a/openstack/obs/error.go
+++ b/openstack/obs/error.go
@@ -20,16 +20,17 @@ import (
 // ObsError defines error response from OBS
 type ObsError struct {
 	BaseModel
-	Status   string
-	XMLName  xml.Name `xml:"Error"`
-	Code     string   `xml:"Code" json:"code"`
-	Message  string   `xml:"Message" json:"message"`
-	Resource string   `xml:"Resource"`
-	HostId   string   `xml:"HostId"`
+	Status    string
+	XMLName   xml.Name `xml:"Error"`
+	Code      string   `xml:"Code" json:"code"`
+	Message   string   `xml:"Message" json:"message"`
+	Resource  string   `xml:"Resource"`
+	HostId    string   `xml:"HostId"`
+	Indicator string
 }
 
 // Format print obs error's log
 func (err ObsError) Error() string {
-	return fmt.Sprintf("obs: service returned error: Status=%s, Code=%s, Message=%s, RequestId=%s",
-		err.Status, err.Code, err.Message, err.RequestId)
+	return fmt.Sprintf("obs: service returned error: Status=%s, Code=%s, Message=%s, RequestId=%s, Indicator=%s.",
+		err.Status, err.Code, err.Message, err.RequestId, err.Indicator)
 }

--- a/openstack/obs/http.go
+++ b/openstack/obs/http.go
@@ -152,7 +152,7 @@ func (obsClient ObsClient) doAction(action, method, bucketName, objectKey string
 
 	for _, extension := range extensions {
 		if extensionHeader, ok := extension.(extensionHeaders); ok {
-			if _err := extensionHeader(headers, isObs); err != nil {
+			if _err := extensionHeader(headers, isObs); _err != nil {
 				doLog(LEVEL_INFO, fmt.Sprintf("set header with error: %v", _err))
 			}
 		} else {
@@ -195,7 +195,9 @@ func (obsClient ObsClient) getSignedURLResponse(action string, output IBaseModel
 		respError = err
 		resp = nil
 	} else {
-		doLog(LEVEL_DEBUG, "Response headers: %s", logResponseHeader(resp.Header))
+		if logConf.level <= LEVEL_DEBUG {
+			doLog(LEVEL_DEBUG, "Response headers: %s", logResponseHeader(resp.Header))
+		}
 		if resp.StatusCode >= 300 {
 			respError = ParseResponseToObsError(resp, isObs)
 			msg = resp.Status
@@ -352,7 +354,9 @@ func logHeaders(headers map[string][]string, signature SignatureType) {
 		} else if securityToken, isSecurityToken = headers[HEADER_STS_TOKEN_OBS]; isSecurityToken {
 			headers[HEADER_STS_TOKEN_OBS] = []string{"******"}
 		}
-		doLog(LEVEL_DEBUG, "Request headers: %s", logRequestHeader(headers))
+		if logConf.level <= LEVEL_DEBUG {
+			doLog(LEVEL_DEBUG, "Request headers: %s", logRequestHeader(headers))
+		}
 		headers[HEADER_AUTH_CAMEL] = auth
 		if isSecurityToken {
 			if signature == SignatureObs {
@@ -474,6 +478,11 @@ func handleBody(req *http.Request, body io.Reader, listener ProgressListener, tr
 		readerLen, err := GetReaderLen(reader)
 		if err == nil {
 			req.ContentLength = readerLen
+
+			// Support Content-Length in Go for uploads, including zero-length scenarios.
+			if req.Method == http.MethodPut && readerLen == 0 {
+				reader = nil
+			}
 		}
 		if req.ContentLength > 0 {
 			req.Header.Set(HEADER_CONTENT_LENGTH_CAMEL, strconv.FormatInt(req.ContentLength, 10))
@@ -528,9 +537,9 @@ func (obsClient ObsClient) doHTTP(method, bucketName, objectKey string, params m
 
 		handleBody(req, _data, listener, tracker)
 
-		logHeaders(headers, obsClient.conf.signature)
-
 		lastRequest = prepareReq(headers, req, lastRequest, obsClient.conf.userAgent)
+
+		logHeaders(lastRequest.Header, obsClient.conf.signature)
 
 		// Transfer started
 		event := newProgressEvent(TransferStartedEvent, 0, req.ContentLength)
@@ -550,7 +559,9 @@ func (obsClient ObsClient) doHTTP(method, bucketName, objectKey string, params m
 				break
 			}
 		} else {
-			doLog(LEVEL_DEBUG, "Response headers: %s", logResponseHeader(resp.Header))
+			if logConf.level <= LEVEL_DEBUG {
+				doLog(LEVEL_DEBUG, "resp.StatusCode [%d] resp.Status [%s] Response headers: [%s]", resp.StatusCode, resp.Status, logResponseHeader(resp.Header))
+			}
 			if resp.StatusCode < 300 {
 				event := newProgressEvent(TransferCompletedEvent, tracker.completedBytes, req.ContentLength)
 				publishProgress(listener, event)

--- a/openstack/obs/log.go
+++ b/openstack/obs/log.go
@@ -21,6 +21,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Level defines the level of the log
@@ -63,24 +64,24 @@ func getDefaultLogConf() logConfType {
 var logConf logConfType
 
 type loggerWrapper struct {
-	fullPath        string
-	fd              *os.File
-	ch              chan string
-	wg              sync.WaitGroup
-	queue           []string
-	logger          *log.Logger
-	index           int
-	cacheCount      int
-	closed          bool
-	formatLoggerNow func(string) string
+	fullPath   string
+	fd         *os.File
+	ch         chan string
+	wg         sync.WaitGroup
+	queue      []string
+	logger     *log.Logger
+	index      int
+	cacheCount int
+	closed     bool
+	loc        *time.Location
 }
 
 func (lw *loggerWrapper) doInit() {
 	lw.queue = make([]string, 0, lw.cacheCount)
 	lw.logger = log.New(lw.fd, "", 0)
 	lw.ch = make(chan string, lw.cacheCount)
-	if lw.formatLoggerNow == nil {
-		lw.formatLoggerNow = FormatUtcNow
+	if lw.loc == nil {
+		lw.loc = time.FixedZone("UTC", 0)
 	}
 	lw.wg.Add(1)
 	go lw.doWrite()
@@ -98,7 +99,7 @@ func (lw *loggerWrapper) rotate() {
 	if stat.Size() >= logConf.maxLogSize {
 		_err := lw.fd.Sync()
 		if _err != nil {
-			panic(err)
+			panic(_err)
 		}
 		_err = lw.fd.Close()
 		if _err != nil {
@@ -109,7 +110,7 @@ func (lw *loggerWrapper) rotate() {
 		}
 		_err = os.Rename(lw.fullPath, lw.fullPath+"."+IntToString(lw.index))
 		if _err != nil {
-			panic(err)
+			panic(_err)
 		}
 		lw.index++
 
@@ -198,9 +199,9 @@ func reset() {
 
 type logConfig func(lw *loggerWrapper)
 
-func WithFormatLoggerTime(formatNow func(string) string) logConfig {
+func WithLoggerTimeLoc(loc *time.Location) logConfig {
 	return func(lw *loggerWrapper) {
-		lw.formatLoggerNow = formatNow
+		lw.loc = loc
 	}
 }
 
@@ -339,11 +340,12 @@ func doLog(level Level, format string, v ...interface{}) {
 			_ = recover()
 			// ignore ch closed error
 		}()
+		nowDate := FormatNowWithLoc("2006-01-02T15:04:05.000ZZ", fileLogger.loc)
+
 		if consoleLogger != nil {
 			consoleLogger.Printf("%s%s", prefix, msg)
 		}
 		if fileLogger != nil {
-			nowDate := fileLogger.formatLoggerNow("2006-01-02T15:04:05.000ZZ")
 			fileLogger.Printf("%s %s%s", nowDate, prefix, msg)
 		}
 	}
@@ -362,10 +364,10 @@ func logResponseHeader(respHeader http.Header) string {
 		if key == "" {
 			continue
 		}
-		if strings.HasPrefix(key, HEADER_PREFIX) || strings.HasPrefix(key, HEADER_PREFIX_OBS) {
-			key = key[len(HEADER_PREFIX):]
-		}
 		_key := strings.ToLower(key)
+		if strings.HasPrefix(_key, HEADER_PREFIX) || strings.HasPrefix(_key, HEADER_PREFIX_OBS) {
+			_key = _key[len(HEADER_PREFIX):]
+		}
 		if _, ok := allowedLogResponseHTTPHeaderNames[_key]; ok {
 			resp = append(resp, fmt.Sprintf("%s: [%s]", key, value[0]))
 		}

--- a/openstack/obs/model_base.go
+++ b/openstack/obs/model_base.go
@@ -239,7 +239,7 @@ type BucketLoggingStatus struct {
 
 // Transition defines transition property in LifecycleRule
 type Transition struct {
-	XMLName      xml.Name         `xml:"Transition"`
+	XMLName      xml.Name         `xml:"Transition" json:"-"`
 	Date         time.Time        `xml:"Date,omitempty"`
 	Days         int              `xml:"Days,omitempty"`
 	StorageClass StorageClassType `xml:"StorageClass"`
@@ -247,7 +247,7 @@ type Transition struct {
 
 // Expiration defines expiration property in LifecycleRule
 type Expiration struct {
-	XMLName                   xml.Name  `xml:"Expiration"`
+	XMLName                   xml.Name  `xml:"Expiration" json:"-"`
 	Date                      time.Time `xml:"Date,omitempty"`
 	Days                      int       `xml:"Days,omitempty"`
 	ExpiredObjectDeleteMarker string    `xml:"ExpiredObjectDeleteMarker,omitempty"`
@@ -255,20 +255,20 @@ type Expiration struct {
 
 // NoncurrentVersionTransition defines noncurrentVersion transition property in LifecycleRule
 type NoncurrentVersionTransition struct {
-	XMLName        xml.Name         `xml:"NoncurrentVersionTransition"`
+	XMLName        xml.Name         `xml:"NoncurrentVersionTransition" json:"-"`
 	NoncurrentDays int              `xml:"NoncurrentDays"`
 	StorageClass   StorageClassType `xml:"StorageClass"`
 }
 
 // NoncurrentVersionExpiration defines noncurrentVersion expiration property in LifecycleRule
 type NoncurrentVersionExpiration struct {
-	XMLName        xml.Name `xml:"NoncurrentVersionExpiration"`
+	XMLName        xml.Name `xml:"NoncurrentVersionExpiration" json:"-"`
 	NoncurrentDays int      `xml:"NoncurrentDays"`
 }
 
 // AbortIncompleteMultipartUpload defines abortIncomplete expiration property in LifecycleRule
 type AbortIncompleteMultipartUpload struct {
-	XMLName             xml.Name `xml:"AbortIncompleteMultipartUpload"`
+	XMLName             xml.Name `xml:"AbortIncompleteMultipartUpload" json:"-"`
 	DaysAfterInitiation int      `xml:"DaysAfterInitiation"`
 }
 
@@ -286,35 +286,20 @@ type LifecycleRule struct {
 }
 
 type LifecycleFilter struct {
-	XMLName xml.Name `xml:"Filter"`
+	XMLName xml.Name `xml:"Filter" json:"-"`
 	Prefix  string   `xml:"And>Prefix,omitempty"`
 	Tags    []Tag    `xml:"And>Tag,omitempty"`
 }
 
 // BucketEncryptionConfiguration defines the bucket encryption configuration
 type BucketEncryptionConfiguration struct {
-	XMLName        xml.Name `xml:"ServerSideEncryptionConfiguration"`
-	SSEAlgorithm   string   `xml:"Rule>ApplyServerSideEncryptionByDefault>SSEAlgorithm"`
-	KMSMasterKeyID string   `xml:"Rule>ApplyServerSideEncryptionByDefault>KMSMasterKeyID,omitempty"`
-	ProjectID      string   `xml:"Rule>ApplyServerSideEncryptionByDefault>ProjectID,omitempty"`
-}
-
-// ReplicationRule defines bucket cross-region replication rule
-type ReplicationRule struct {
-	ID                          string           `xml:"ID,omitempty"`
-	Prefix                      string           `xml:"Prefix"`
-	Status                      RuleStatusType   `xml:"Status"`
-	DestinationBucket           string           `xml:"Destination>Bucket"`
-	StorageClass                StorageClassType `xml:"Destination>StorageClass,omitempty"`
-	DeleteDate                  EnabledType      `xml:"Destination>DeleteDate,omitempty"`
-	HistoricalObjectReplication EnabledType      `xml:"HistoricalObjectReplication,omitempty"`
-}
-
-// BucketReplicationConfiguration defines the bucket cross-region replication configuration
-type BucketReplicationConfiguration struct {
-	XMLName          xml.Name          `xml:"ReplicationConfiguration"`
-	Agency           string            `xml:"Agency"`
-	ReplicationRules []ReplicationRule `xml:"Rule"`
+	XMLName                 xml.Name `xml:"ServerSideEncryptionConfiguration"`
+	SSEAlgorithm            string   `xml:"Rule>ApplyServerSideEncryptionByDefault>SSEAlgorithm"`
+	KMSMasterKeyID          string   `xml:"Rule>ApplyServerSideEncryptionByDefault>KMSMasterKeyID,omitempty"`
+	KMSDataEncryption       string   `xml:"Rule>ApplyServerSideEncryptionByDefault>KMSDataEncryption,omitempty"`
+	ProjectID               string   `xml:"Rule>ApplyServerSideEncryptionByDefault>ProjectID,omitempty"`
+	BucketKeyEnabled        bool     `xml:"Rule>BucketKeyEnabled,omitempty"`
+	BucketKeyRotationPeriod int64    `xml:"Rule>BucketKeyRotationPeriod,omitempty"`
 }
 
 // Tag defines tag property in BucketTagging
@@ -394,6 +379,24 @@ type Part struct {
 type BucketPayer struct {
 	XMLName xml.Name  `xml:"RequestPaymentConfiguration"`
 	Payer   PayerType `xml:"Payer"`
+}
+
+type PublicAccessBlockConfiguration struct {
+	XMLName               xml.Name `xml:"PublicAccessBlockConfiguration"`
+	BlockPublicAcls       bool     `xml:"BlockPublicAcls"`
+	IgnorePublicAcls      bool     `xml:"IgnorePublicAcls"`
+	BlockPublicPolicy     bool     `xml:"BlockPublicPolicy"`
+	RestrictPublicBuckets bool     `xml:"RestrictPublicBuckets"`
+}
+
+type PolicyPublicStatus struct {
+	XMLName  xml.Name `xml:"PolicyStatus"`
+	IsPublic bool     `xml:"IsPublic"`
+}
+
+type BucketPublicStatus struct {
+	XMLName  xml.Name `xml:"BucketStatus"`
+	IsPublic bool     `xml:"IsPublic"`
 }
 
 // HttpHeader defines the standard metadata

--- a/openstack/obs/model_base.go
+++ b/openstack/obs/model_base.go
@@ -302,6 +302,24 @@ type BucketEncryptionConfiguration struct {
 	BucketKeyRotationPeriod int64    `xml:"Rule>BucketKeyRotationPeriod,omitempty"`
 }
 
+// ReplicationRule defines bucket cross-region replication rule
+type ReplicationRule struct {
+	ID                          string           `xml:"ID,omitempty"`
+	Prefix                      string           `xml:"Prefix"`
+	Status                      RuleStatusType   `xml:"Status"`
+	DestinationBucket           string           `xml:"Destination>Bucket"`
+	StorageClass                StorageClassType `xml:"Destination>StorageClass,omitempty"`
+	DeleteDate                  EnabledType      `xml:"Destination>DeleteDate,omitempty"`
+	HistoricalObjectReplication EnabledType      `xml:"HistoricalObjectReplication,omitempty"`
+}
+
+// BucketReplicationConfiguration defines the bucket cross-region replication configuration
+type BucketReplicationConfiguration struct {
+	XMLName          xml.Name          `xml:"ReplicationConfiguration"`
+	Agency           string            `xml:"Agency"`
+	ReplicationRules []ReplicationRule `xml:"Rule"`
+}
+
 // Tag defines tag property in BucketTagging
 type Tag struct {
 	XMLName xml.Name `xml:"Tag"`

--- a/openstack/obs/model_bucket.go
+++ b/openstack/obs/model_bucket.go
@@ -300,6 +300,18 @@ type GetBucketEncryptionOutput struct {
 	BucketEncryptionConfiguration
 }
 
+// SetBucketReplicationInput is the input parameter of SetBucketReplication function
+type SetBucketReplicationInput struct {
+	Bucket string `xml:"-"`
+	BucketReplicationConfiguration
+}
+
+// GetBucketReplicationOutput is the result of GetBucketReplication function
+type GetBucketReplicationOutput struct {
+	BaseModel
+	BucketReplicationConfiguration
+}
+
 // SetBucketTaggingInput is the input parameter of SetBucketTagging function
 type SetBucketTaggingInput struct {
 	Bucket string `xml:"-"`

--- a/openstack/obs/model_bucket.go
+++ b/openstack/obs/model_bucket.go
@@ -14,6 +14,7 @@ package obs
 
 import (
 	"encoding/xml"
+	"time"
 )
 
 // DeleteBucketCustomDomainInput is the input parameter of DeleteBucketCustomDomain function
@@ -22,20 +23,27 @@ type DeleteBucketCustomDomainInput struct {
 	CustomDomain string
 }
 
-// GetBucketCustomDomainOuput is the result of GetBucketCustomdomain function
-type GetBucketCustomDomainOuput struct {
+// GetBucketCustomDomainOutput is the result of GetBucketCustomDomain function
+type GetBucketCustomDomainOutput struct {
 	BaseModel
 	Domains []Domain `xml:"Domains"`
 }
 
-// SetBucketCustomDomainInput is the input parameter of SetBucketCustomDomain function
+type CustomDomainConfiguration struct {
+	Name             string `xml:"Name"`
+	CertificateId    string `xml:"CertificateId,omitempty"`
+	Certificate      string `xml:"Certificate"`
+	CertificateChain string `xml:"CertificateChain,omitempty"`
+	PrivateKey       string `xml:"PrivateKey"`
+}
 type SetBucketCustomDomainInput struct {
-	Bucket       string
-	CustomDomain string
+	Bucket                    string
+	CustomDomain              string
+	CustomDomainConfiguration *CustomDomainConfiguration `json:"customDomainConfiguration"` //optional
 }
 
-// GetBucketMirrorBackToSourceOuput is the result of GetBucketMirrorBackToSource function
-type GetBucketMirrorBackToSourceOuput struct {
+// GetBucketMirrorBackToSourceOutput is the result of GetBucketMirrorBackToSource function
+type GetBucketMirrorBackToSourceOutput struct {
 	BaseModel
 	Rules string `json:"body"`
 }
@@ -47,8 +55,9 @@ type SetBucketMirrorBackToSourceInput struct {
 
 // Content defines the object content properties
 type Domain struct {
-	DomainName string `xml:"DomainName"`
-	CreateTime string `xml:"CreateTime"`
+	DomainName    string `xml:"DomainName"`
+	CreateTime    string `xml:"CreateTime"`
+	CertificateId string `xml:"CertificateId"`
 }
 
 // ListBucketsInput is the input parameter of ListBuckets function
@@ -90,6 +99,14 @@ type CreateBucketInput struct {
 	BucketRedundancy            BucketRedundancyType `xml:"-"`
 	IsFusionAllowUpgrade        bool                 `xml:"-"`
 	IsRedundancyAllowALT        bool                 `xml:"-"`
+	SseHeader                   ISseHeader
+}
+
+type CreateBucketOutput struct {
+	BaseModel
+	Date      time.Time `xml:"-"`
+	Location  string    `xml:"-"`
+	SseHeader ISseHeader
 }
 
 // SetBucketStoragePolicyInput is the input parameter of SetBucketStoragePolicy function
@@ -183,6 +200,7 @@ type GetBucketPolicyOutput struct {
 type SetBucketCorsInput struct {
 	Bucket string `xml:"-"`
 	BucketCors
+	EnableSha256 bool `xml:"-"`
 }
 
 // GetBucketCorsOutput is the result of GetBucketCors function
@@ -253,7 +271,7 @@ type GetBucketLoggingConfigurationOutput struct {
 
 // BucketLifecycleConfiguration defines the bucket lifecycle configuration
 type BucketLifecycleConfiguration struct {
-	XMLName        xml.Name        `xml:"LifecycleConfiguration"`
+	XMLName        xml.Name        `xml:"LifecycleConfiguration" json:"-"`
 	LifecycleRules []LifecycleRule `xml:"Rule"`
 }
 
@@ -261,6 +279,7 @@ type BucketLifecycleConfiguration struct {
 type SetBucketLifecycleConfigurationInput struct {
 	Bucket string `xml:"-"`
 	BucketLifecycleConfiguration
+	EnableSha256 bool `xml:"-"`
 }
 
 // GetBucketLifecycleConfigurationOutput is the result of GetBucketLifecycleConfiguration function
@@ -281,22 +300,11 @@ type GetBucketEncryptionOutput struct {
 	BucketEncryptionConfiguration
 }
 
-// SetBucketReplicationInput is the input parameter of SetBucketReplication function
-type SetBucketReplicationInput struct {
-	Bucket string `xml:"-"`
-	BucketReplicationConfiguration
-}
-
-// GetBucketReplicationOutput is the result of GetBucketReplication function
-type GetBucketReplicationOutput struct {
-	BaseModel
-	BucketReplicationConfiguration
-}
-
 // SetBucketTaggingInput is the input parameter of SetBucketTagging function
 type SetBucketTaggingInput struct {
 	Bucket string `xml:"-"`
 	BucketTagging
+	EnableSha256 bool `xml:"-"`
 }
 
 // GetBucketTaggingOutput is the result of GetBucketTagging function
@@ -388,4 +396,50 @@ type GetBucketFSStatusInput struct {
 type GetBucketFSStatusOutput struct {
 	GetBucketMetadataOutput
 	FSStatus FSStatusType
+}
+
+type SetDirAccesslabelInput struct {
+	BaseDirAccesslabelInput
+	Accesslabel []string
+}
+
+type GetDirAccesslabelInput struct {
+	BaseDirAccesslabelInput
+}
+
+type GetDirAccesslabelOutput struct {
+	BaseModel
+	Accesslabel []string
+}
+
+type DeleteDirAccesslabelInput struct {
+	BaseDirAccesslabelInput
+	Accesslabel []string
+}
+
+type BaseDirAccesslabelInput struct {
+	Bucket      string
+	Key         string
+	Accesslabel []string
+}
+
+// PutBucketPublicAccessBlockInput is the input parameter of PutBucketPublicAccessBlock function
+type PutBucketPublicAccessBlockInput struct {
+	Bucket string `xml:"-"`
+	PublicAccessBlockConfiguration
+}
+
+type GetBucketPublicAccessBlockOutput struct {
+	BaseModel
+	PublicAccessBlockConfiguration
+}
+
+type GetBucketPublicStatusOutput struct {
+	BaseModel
+	BucketPublicStatus
+}
+
+type GetBucketPolicyPublicStatusOutput struct {
+	BaseModel
+	PolicyPublicStatus
 }

--- a/openstack/obs/model_header.go
+++ b/openstack/obs/model_header.go
@@ -20,9 +20,13 @@ type ISseHeader interface {
 
 // SseKmsHeader defines the SseKms header
 type SseKmsHeader struct {
-	Encryption string
-	Key        string
-	isObs      bool
+	Encryption       string
+	DataEncryption   string
+	BucketKeyEnabled bool
+	RotationPeriod   int64
+	Key              string
+	ProjectID        string
+	isObs            bool
 }
 
 // SseCHeader defines the SseC header

--- a/openstack/obs/model_object.go
+++ b/openstack/obs/model_object.go
@@ -35,6 +35,15 @@ type ListObjectsInput struct {
 	Marker string
 }
 
+type ListPosixObjectsInput struct {
+	ListObjectsInput
+}
+
+type Tagging struct {
+	XMLName xml.Name `xml:"Tagging"`
+	Tags    []Tag    `xml:"TagSet>Tag"`
+}
+
 // ListObjectsOutput is the result of ListObjects function
 type ListObjectsOutput struct {
 	BaseModel
@@ -50,6 +59,20 @@ type ListObjectsOutput struct {
 	CommonPrefixes []string  `xml:"CommonPrefixes>Prefix"`
 	Location       string    `xml:"-"`
 	EncodingType   string    `xml:"EncodingType,omitempty"`
+}
+
+type ListPosixObjectsOutput struct {
+	ListObjectsOutput
+	CommonPrefixes []CommonPrefix `xml:"CommonPrefixes"`
+}
+
+type CommonPrefix struct {
+	XMLName      xml.Name  `xml:"CommonPrefixes"`
+	Prefix       string    `xml:"Prefix"`
+	MTime        string    `xml:"MTime"`
+	Mode         string    `xml:"Mode"`
+	InodeNo      string    `xml:"InodeNo"`
+	LastModified time.Time `xml:"LastModified"`
 }
 
 // ListVersionsInput is the input parameter of ListVersions function
@@ -167,7 +190,6 @@ type GetObjectMetadataOutput struct {
 	NextAppendPosition      string
 	StorageClass            StorageClassType
 	ContentLength           int64
-	ContentType             string
 	ETag                    string
 	AllowOrigin             string
 	AllowHeader             string
@@ -199,6 +221,7 @@ type GetObjectInput struct {
 	IfModifiedSince            time.Time
 	RangeStart                 int64
 	RangeEnd                   int64
+	Range                      string
 	ImageProcess               string
 	ResponseCacheControl       string
 	ResponseContentDisposition string
@@ -211,13 +234,9 @@ type GetObjectInput struct {
 // GetObjectOutput is the result of GetObject function
 type GetObjectOutput struct {
 	GetObjectMetadataOutput
-	DeleteMarker       bool
-	CacheControl       string
-	ContentDisposition string
-	ContentEncoding    string
-	ContentLanguage    string
-	Expires            string
-	Body               io.ReadCloser
+	DeleteMarker bool
+	Expires      string
+	Body         io.ReadCloser
 }
 
 // ObjectOperationInput defines the object operation properties
@@ -234,13 +253,14 @@ type ObjectOperationInput struct {
 	Expires                 int64
 	SseHeader               ISseHeader
 	Metadata                map[string]string
-	HttpHeader
 }
 
 // PutObjectBasicInput defines the basic object operation properties
 type PutObjectBasicInput struct {
 	ObjectOperationInput
+	HttpHeader
 	ContentMD5    string
+	ContentSHA256 string
 	ContentLength int64
 }
 
@@ -287,14 +307,10 @@ type CopyObjectInput struct {
 	CopySourceIfUnmodifiedSince time.Time
 	CopySourceIfModifiedSince   time.Time
 	SourceSseHeader             ISseHeader
-	CacheControl                string
-	ContentDisposition          string
-	ContentEncoding             string
-	ContentLanguage             string
-	ContentType                 string
 	Expires                     string
 	MetadataDirective           MetadataDirectiveType
 	SuccessActionRedirect       string
+	HttpHeader
 }
 
 // CopyObjectOutput is the result of CopyObject function
@@ -311,13 +327,13 @@ type CopyObjectOutput struct {
 // UploadFileInput is the input parameter of UploadFile function
 type UploadFileInput struct {
 	ObjectOperationInput
-	ContentType      string
 	UploadFile       string
 	PartSize         int64
 	TaskNum          int
 	EnableCheckpoint bool
 	CheckpointFile   string
 	EncodingType     string
+	HttpHeader
 }
 
 // DownloadFileInput is the input parameter of DownloadFile function
@@ -403,17 +419,60 @@ type SetObjectMetadataInput struct {
 	HttpHeader
 }
 
+type ObjectTaggingInput struct {
+	Bucket    string
+	Key       string
+	VersionId string
+}
+
+// GetObjectTaggingInput is the input parameter of GetObjectTagging function
+type GetObjectTaggingInput struct {
+	ObjectTaggingInput
+}
+
+// SetObjectTaggingInput is the input parameter of SetObjectTagging function
+type SetObjectTaggingInput struct {
+	ObjectTaggingInput
+	Tags []Tag
+}
+
+type DeleteObjectTaggingInput struct {
+	ObjectTaggingInput
+}
+
+type ObjectTaggingOutput struct {
+	BaseModel
+	VersionId string
+}
+
+type GetObjectTaggingOutput struct {
+	ObjectTaggingOutput
+	XMLName xml.Name `xml:"Tagging"`
+	Tags    []Tag    `xml:"TagSet>Tag"`
+}
+
+type SetObjectTaggingOutput struct {
+	ObjectTaggingOutput
+}
+
+type DeleteObjectTaggingOutput struct {
+	ObjectTaggingOutput
+}
+
 // SetObjectMetadataOutput is the result of SetObjectMetadata function
 type SetObjectMetadataOutput struct {
 	BaseModel
-	MetadataDirective       MetadataDirectiveType
-	CacheControl            string
-	ContentDisposition      string
-	ContentEncoding         string
-	ContentLanguage         string
-	ContentType             string
+	MetadataDirective MetadataDirectiveType
+	HttpHeader
 	Expires                 string
 	WebsiteRedirectLocation string
 	StorageClass            StorageClassType
 	Metadata                map[string]string
+}
+
+type CallbackInput struct {
+	CallbackUrl      string `json:"callbackUrl"`
+	CallbackHost     string `json:"callbackHost,omitempty"`
+	CallbackBody     string `json:"callbackBody"`
+	CallbackBodyType string `json:"callbackBodyType,omitempty"`
 }

--- a/openstack/obs/model_other.go
+++ b/openstack/obs/model_other.go
@@ -34,12 +34,20 @@ type CreateSignedUrlOutput struct {
 	ActualSignedRequestHeaders http.Header
 }
 
+// ConditionRange the specifying ranges in the conditions
+type ConditionRange struct {
+	RangeName string
+	Lower     int64
+	Upper     int64
+}
+
 // CreateBrowserBasedSignatureInput is the input parameter of CreateBrowserBasedSignature function.
 type CreateBrowserBasedSignatureInput struct {
-	Bucket     string
-	Key        string
-	Expires    int
-	FormParams map[string]string
+	Bucket      string
+	Key         string
+	Expires     int
+	FormParams  map[string]string
+	RangeParams []ConditionRange
 }
 
 // CreateBrowserBasedSignatureOutput is the result of CreateBrowserBasedSignature function.

--- a/openstack/obs/model_part.go
+++ b/openstack/obs/model_part.go
@@ -57,7 +57,7 @@ type AbortMultipartUploadInput struct {
 // InitiateMultipartUploadInput is the input parameter of InitiateMultipartUpload function
 type InitiateMultipartUploadInput struct {
 	ObjectOperationInput
-	ContentType  string
+	HttpHeader
 	EncodingType string
 }
 
@@ -74,16 +74,17 @@ type InitiateMultipartUploadOutput struct {
 
 // UploadPartInput is the input parameter of UploadPart function
 type UploadPartInput struct {
-	Bucket     string
-	Key        string
-	PartNumber int
-	UploadId   string
-	ContentMD5 string
-	SseHeader  ISseHeader
-	Body       io.Reader
-	SourceFile string
-	Offset     int64
-	PartSize   int64
+	Bucket        string
+	Key           string
+	PartNumber    int
+	UploadId      string
+	ContentMD5    string
+	ContentSHA256 string
+	SseHeader     ISseHeader
+	Body          io.Reader
+	SourceFile    string
+	Offset        int64
+	PartSize      int64
 }
 
 // UploadPartOutput is the result of UploadPart function
@@ -157,6 +158,7 @@ type CopyPartInput struct {
 	CopySourceVersionId  string
 	CopySourceRangeStart int64
 	CopySourceRangeEnd   int64
+	CopySourceRange      string
 	SseHeader            ISseHeader
 	SourceSseHeader      ISseHeader
 }

--- a/openstack/obs/progress.go
+++ b/openstack/obs/progress.go
@@ -1,3 +1,14 @@
+// Copyright 2019 Huawei Technologies Co.,Ltd.
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License.  You may obtain a copy of the
+// License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations under the License.
 package obs
 
 import (

--- a/openstack/obs/temporary_other.go
+++ b/openstack/obs/temporary_other.go
@@ -93,9 +93,17 @@ func (obsClient ObsClient) CreateBrowserBasedSignature(input *CreateBrowserBased
 		originPolicySlice = append(originPolicySlice, "[\"starts-with\", \"$key\", \"\"],")
 	}
 
+	for _, v := range input.RangeParams {
+		originPolicySlice = append(originPolicySlice, fmt.Sprintf("[\"%s\", %d, %d],", v.RangeName, v.Lower, v.Upper))
+	}
+
+	lastIndex := len(originPolicySlice) - 1
+	originPolicySlice[lastIndex] = strings.TrimSuffix(originPolicySlice[lastIndex], ",")
+
 	originPolicySlice = append(originPolicySlice, "]}")
 
 	originPolicy := strings.Join(originPolicySlice, "")
+
 	policy := Base64Encode([]byte(originPolicy))
 	var signature string
 	if obsClient.conf.signature == SignatureV4 {

--- a/openstack/obs/trait_base.go
+++ b/openstack/obs/trait_base.go
@@ -14,6 +14,7 @@ package obs
 
 import (
 	"io"
+	"strconv"
 )
 
 type IRepeatable interface {
@@ -112,6 +113,22 @@ func (header SseKmsHeader) GetKey() string {
 	return header.Key
 }
 
+func (header SseKmsHeader) GetDataEncryption() string {
+	return header.DataEncryption
+}
+
+func (header SseKmsHeader) GetBucketKeyEnabled() bool {
+	return header.BucketKeyEnabled
+}
+
+func (header SseKmsHeader) GetProjectId() string {
+	return header.ProjectID
+}
+
+func (header SseKmsHeader) GetRotationPeriod() int64 {
+	return header.RotationPeriod
+}
+
 // GetEncryption gets the Encryption field value from SseCHeader
 func (header SseCHeader) GetEncryption() string {
 	if header.Encryption != "" {
@@ -137,17 +154,33 @@ func (header SseCHeader) GetKeyMD5() string {
 	return ""
 }
 
-func setSseHeader(headers map[string][]string, sseHeader ISseHeader, sseCOnly bool, isObs bool) {
+func setSseHeader(headers map[string][]string, sseHeader ISseHeader, sseCOnly bool, sseKmsOnly bool, isObs bool) {
 	if sseHeader != nil {
-		if sseCHeader, ok := sseHeader.(SseCHeader); ok {
+		if sseCHeader, ok := sseHeader.(SseCHeader); !sseKmsOnly && ok {
 			setHeaders(headers, HEADER_SSEC_ENCRYPTION, []string{sseCHeader.GetEncryption()}, isObs)
 			setHeaders(headers, HEADER_SSEC_KEY, []string{sseCHeader.GetKey()}, isObs)
 			setHeaders(headers, HEADER_SSEC_KEY_MD5, []string{sseCHeader.GetKeyMD5()}, isObs)
 		} else if sseKmsHeader, ok := sseHeader.(SseKmsHeader); !sseCOnly && ok {
-			sseKmsHeader.isObs = isObs
 			setHeaders(headers, HEADER_SSEKMS_ENCRYPTION, []string{sseKmsHeader.GetEncryption()}, isObs)
 			if sseKmsHeader.GetKey() != "" {
 				setHeadersNext(headers, HEADER_SSEKMS_KEY_OBS, HEADER_SSEKMS_KEY_AMZ, []string{sseKmsHeader.GetKey()}, isObs)
+			}
+
+			if sseKmsHeader.GetProjectId() != "" {
+				setHeaders(headers, HEADER_SSEKMS_KEY_PROJECT, []string{sseKmsHeader.GetProjectId()}, isObs)
+			}
+
+			if sseKmsHeader.GetDataEncryption() != "" {
+				setHeaders(headers, HEADER_SSEKMS_DATA_ENCRYPTION, []string{sseKmsHeader.GetDataEncryption()}, isObs)
+			}
+
+			if sseKmsHeader.GetBucketKeyEnabled() {
+				setHeaders(headers, HEADER_SSEKMS_ENCRYPT_BUCKET_KEY_ENABLED, []string{"true"}, isObs)
+			}
+
+			if sseKmsHeader.GetRotationPeriod() >= 0 {
+				ret := strconv.FormatInt(sseKmsHeader.GetRotationPeriod(), 10)
+				setHeaders(headers, HEADER_SSEKMS_ENCRYPT_BUCKET_KEY_ROTATION_PERIOD, []string{ret}, isObs)
 			}
 		}
 	}

--- a/openstack/obs/trait_bucket.go
+++ b/openstack/obs/trait_bucket.go
@@ -70,6 +70,8 @@ func (input CreateBucketInput) trans(isObs bool) (params map[string]string, head
 				storageClass = string(storageClassStandardIA)
 			} else if storageClass == string(StorageClassCold) {
 				storageClass = string(storageClassGlacier)
+			} else if storageClass == string(StorageClassIntelligentTiering) {
+				doLog(LEVEL_WARN, "Intelligent tiering supports only OBS signature.")
 			}
 		}
 		setHeadersNext(headers, HEADER_STORAGE_CLASS_OBS, HEADER_STORAGE_CLASS, []string{storageClass}, isObs)
@@ -85,6 +87,8 @@ func (input CreateBucketInput) trans(isObs bool) (params map[string]string, head
 	if input.IsFSFileInterface {
 		setHeaders(headers, headerFSFileInterface, []string{"Enabled"}, true)
 	}
+
+	setSseHeader(headers, input.SseHeader, false, true, isObs)
 
 	if location := strings.TrimSpace(input.Location); location != "" {
 		input.Location = location
@@ -125,6 +129,8 @@ func (input SetBucketStoragePolicyInput) trans(isObs bool) (params map[string]st
 			storageClass = storageClassStandardIA
 		} else if input.StorageClass == StorageClassCold {
 			storageClass = storageClassGlacier
+		} else if storageClass == StorageClassIntelligentTiering {
+			doLog(LEVEL_WARN, "Intelligent tiering supports only OBS signature.")
 		}
 		params = map[string]string{string(SubResourceStoragePolicy): ""}
 		xml = append(xml, fmt.Sprintf("<StoragePolicy><DefaultStorageClass>%s</DefaultStorageClass></StoragePolicy>", storageClass))
@@ -163,11 +169,17 @@ func (input SetBucketPolicyInput) trans(isObs bool) (params map[string]string, h
 
 func (input SetBucketCorsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{string(SubResourceCors): ""}
-	data, md5, err := ConvertRequestToIoReaderV2(input)
+	data, md5OrSha256, err := ConvertRequestToIoReaderV2(input, input.EnableSha256)
 	if err != nil {
 		return
 	}
-	headers = map[string][]string{HEADER_MD5_CAMEL: {md5}}
+
+	headerCheckAlgorithm := HEADER_MD5_CAMEL
+	if input.EnableSha256 {
+		headerCheckAlgorithm = HEADER_SHA256_CAMEL
+	}
+
+	headers = map[string][]string{headerCheckAlgorithm: {md5OrSha256}}
 	return
 }
 
@@ -200,8 +212,15 @@ func (input SetBucketLoggingConfigurationInput) trans(isObs bool) (params map[st
 
 func (input SetBucketLifecycleConfigurationInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{string(SubResourceLifecycle): ""}
-	data, md5 := ConvertLifecycleConfigurationToXml(input.BucketLifecycleConfiguration, true, isObs)
-	headers = map[string][]string{HEADER_MD5_CAMEL: {md5}}
+
+	data, md5OrSha256 := ConvertLifecycleConfigurationToXml(input.BucketLifecycleConfiguration, true, isObs, input.EnableSha256)
+
+	headerCheckAlgorithm := HEADER_MD5_CAMEL
+	if input.EnableSha256 {
+		headerCheckAlgorithm = HEADER_SHA256_CAMEL
+	}
+
+	headers = map[string][]string{headerCheckAlgorithm: {md5OrSha256}}
 	return
 }
 
@@ -211,20 +230,19 @@ func (input SetBucketEncryptionInput) trans(isObs bool) (params map[string]strin
 	return
 }
 
-func (input SetBucketReplicationInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
-	params = map[string]string{string(SubResourceReplication): ""}
-	data, md5 := convertReplicationConfigurationToXml(input.BucketReplicationConfiguration, true, isObs)
-	headers = map[string][]string{HEADER_MD5_CAMEL: {md5}}
-	return
-}
-
 func (input SetBucketTaggingInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{string(SubResourceTagging): ""}
-	data, md5, err := ConvertRequestToIoReaderV2(input)
+	data, md5OrSha256, err := ConvertRequestToIoReaderV2(input, input.EnableSha256)
 	if err != nil {
 		return
 	}
-	headers = map[string][]string{HEADER_MD5_CAMEL: {md5}}
+
+	headerCheckAlgorithm := HEADER_MD5_CAMEL
+	if input.EnableSha256 {
+		headerCheckAlgorithm = HEADER_SHA256_CAMEL
+	}
+
+	headers = map[string][]string{headerCheckAlgorithm: {md5OrSha256}}
 	return
 }
 
@@ -276,10 +294,8 @@ func (input GetBucketFetchJobInput) trans(isObs bool) (params map[string]string,
 
 func (input SetBucketMirrorBackToSourceInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{string(SubResourceMirrorBackToSource): ""}
-
-	contentType, _ := mimeTypes["json"]
 	headers = make(map[string][]string, 1)
-	headers[HEADER_CONTENT_TYPE] = []string{contentType}
+	headers[HEADER_CONTENT_TYPE] = []string{mimeTypes["json"]}
 	data = input.Rules
 	return
 }
@@ -288,6 +304,52 @@ func (input DeleteBucketCustomDomainInput) trans(isObs bool) (params map[string]
 	return trans(SubResourceCustomDomain, input)
 }
 
+func handleDomainConfig(customDomainConfiguration CustomDomainConfiguration) (headers map[string][]string, data interface{}, err error) {
+
+	headers = make(map[string][]string)
+	if customDomainConfiguration.CertificateId != "" {
+		err = validateLength(len(customDomainConfiguration.CertificateId), CERT_ID_SIZE, CERT_ID_SIZE, CERTIFICATE_FIELD_NAME)
+		if err != nil {
+			return headers, nil, err
+		}
+	}
+
+	err = validateLength(len(customDomainConfiguration.Name), MIN_CERTIFICATE_NAME_LENGTH, MAX_CERTIFICATE_NAME_LENGTH, NAME_LENGTH)
+	if err != nil {
+		return headers, nil, err
+	}
+
+	reader, md5, convertErr := ConvertRequestToIoReaderV2(customDomainConfiguration, false)
+	if convertErr != nil {
+		return headers, nil, convertErr
+	}
+
+	readerLen, err := GetReaderLen(reader)
+	if err != nil {
+		return headers, nil, err
+	}
+
+	err = validateLength(int(readerLen), 0, MAX_CERT_XML_BODY_SIZE, XML_SIZE)
+	if err != nil {
+		return headers, nil, err
+	}
+	data = reader
+
+	headers = map[string][]string{HEADER_MD5_CAMEL: {md5}}
+	return
+}
+
+// isObs在该场景下不区分
 func (input SetBucketCustomDomainInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
-	return trans(SubResourceCustomDomain, input)
+	params = map[string]string{string(SubResourceCustomDomain): input.CustomDomain}
+	headers = make(map[string][]string)
+	data = nil
+	if input.CustomDomainConfiguration != nil {
+		headers, data, err = handleDomainConfig(*input.CustomDomainConfiguration)
+	}
+	return
+}
+
+func (input PutBucketPublicAccessBlockInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	return trans(SubResourcePublicAccessBlock, input)
 }

--- a/openstack/obs/trait_bucket.go
+++ b/openstack/obs/trait_bucket.go
@@ -230,6 +230,13 @@ func (input SetBucketEncryptionInput) trans(isObs bool) (params map[string]strin
 	return
 }
 
+func (input SetBucketReplicationInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceReplication): ""}
+	data, md5 := convertReplicationConfigurationToXml(input.BucketReplicationConfiguration, true, isObs)
+	headers = map[string][]string{HEADER_MD5_CAMEL: {md5}}
+	return
+}
+
 func (input SetBucketTaggingInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{string(SubResourceTagging): ""}
 	data, md5OrSha256, err := ConvertRequestToIoReaderV2(input, input.EnableSha256)

--- a/openstack/obs/trait_object.go
+++ b/openstack/obs/trait_object.go
@@ -59,6 +59,17 @@ func (input ListObjectsInput) trans(isObs bool) (params map[string]string, heade
 	return
 }
 
+func (input ListPosixObjectsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers, data, err = input.ListObjsInput.trans(isObs)
+	if err != nil {
+		return
+	}
+	if input.Marker != "" {
+		params["marker"] = input.Marker
+	}
+	return
+}
+
 func (input ListVersionsInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params, headers, data, err = input.ListObjsInput.trans(isObs)
 	if err != nil {
@@ -90,6 +101,7 @@ func (input DeleteObjectsInput) trans(isObs bool) (params map[string]string, hea
 		}
 	}
 	data, md5 := convertDeleteObjectsToXML(input)
+
 	headers = map[string][]string{HEADER_MD5_CAMEL: {md5}}
 	return
 }
@@ -124,7 +136,7 @@ func (input RestoreObjectInput) trans(isObs bool) (params map[string]string, hea
 	if !isObs {
 		data, err = ConvertRequestToIoReader(input)
 	} else {
-		data = ConverntObsRestoreToXml(input)
+		data = ConventObsRestoreToXml(input)
 	}
 	return
 }
@@ -143,7 +155,7 @@ func (input GetObjectMetadataInput) trans(isObs bool) (params map[string]string,
 	if input.RequestHeader != "" {
 		headers[HEADER_ACCESS_CONTROL_REQUEST_HEADER_CAMEL] = []string{input.RequestHeader}
 	}
-	setSseHeader(headers, input.SseHeader, true, isObs)
+	setSseHeader(headers, input.SseHeader, true, false, isObs)
 	return
 }
 
@@ -178,14 +190,46 @@ func (input SetObjectMetadataInput) prepareStorageClass(headers map[string][]str
 				storageClass = string(storageClassStandardIA)
 			} else if storageClass == string(StorageClassCold) {
 				storageClass = string(storageClassGlacier)
+			} else if storageClass == string(StorageClassIntelligentTiering) {
+				doLog(LEVEL_WARN, "Intelligent tiering supports only OBS signature.")
 			}
 		}
 		setHeaders(headers, HEADER_STORAGE_CLASS2, []string{storageClass}, isObs)
 	}
 }
 
+func buildTaggingBaseParamsAndHeaders(versionId string) (map[string]string, map[string][]string) {
+	params := map[string]string{string(SubResourceTagging): ""}
+	if versionId != "" {
+		params[PARAM_VERSION_ID] = versionId
+	}
+	headers := make(map[string][]string)
+	return params, headers
+}
+
+func (input GetObjectTaggingInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers = buildTaggingBaseParamsAndHeaders(input.VersionId)
+	return
+}
+
+func (input SetObjectTaggingInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers = buildTaggingBaseParamsAndHeaders(input.VersionId)
+
+	data, md5, e := ConvertObjectTagsToXml(input.Tags, true)
+	if e != nil {
+		err = e
+		return
+	}
+	headers[HEADER_MD5_CAMEL] = []string{md5}
+	return
+}
+
+func (input DeleteObjectTaggingInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params, headers = buildTaggingBaseParamsAndHeaders(input.VersionId)
+	return
+}
+
 func (input SetObjectMetadataInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
-	params = make(map[string]string)
 	params = map[string]string{string(SubResourceMetadata): ""}
 	if input.VersionId != "" {
 		params[PARAM_VERSION_ID] = input.VersionId
@@ -245,6 +289,9 @@ func (input GetObjectInput) trans(isObs bool) (params map[string]string, headers
 	if input.RangeStart >= 0 && input.RangeEnd > input.RangeStart {
 		headers[HEADER_RANGE] = []string{fmt.Sprintf("bytes=%d-%d", input.RangeStart, input.RangeEnd)}
 	}
+	if input.Range != "" {
+		headers[HEADER_RANGE] = []string{input.Range}
+	}
 	if input.AcceptEncoding != "" {
 		headers[HEADER_ACCEPT_ENCODING] = []string{input.AcceptEncoding}
 	}
@@ -291,6 +338,8 @@ func (input ObjectOperationInput) trans(isObs bool) (params map[string]string, h
 				storageClass = string(storageClassStandardIA)
 			} else if storageClass == string(StorageClassCold) {
 				storageClass = string(storageClassGlacier)
+			} else if storageClass == string(StorageClassIntelligentTiering) {
+				doLog(LEVEL_WARN, "Intelligent tiering supports only OBS signature.")
 			}
 		}
 		setHeaders(headers, HEADER_STORAGE_CLASS2, []string{storageClass}, isObs)
@@ -299,7 +348,7 @@ func (input ObjectOperationInput) trans(isObs bool) (params map[string]string, h
 		setHeaders(headers, HEADER_WEBSITE_REDIRECT_LOCATION, []string{input.WebsiteRedirectLocation}, isObs)
 
 	}
-	setSseHeader(headers, input.SseHeader, false, isObs)
+	setSseHeader(headers, input.SseHeader, false, false, isObs)
 	if input.Expires != 0 {
 		setHeaders(headers, HEADER_EXPIRES, []string{Int64ToString(input.Expires)}, true)
 	}
@@ -320,6 +369,10 @@ func (input PutObjectBasicInput) trans(isObs bool) (params map[string]string, he
 
 	if input.ContentMD5 != "" {
 		headers[HEADER_MD5_CAMEL] = []string{input.ContentMD5}
+	}
+
+	if input.ContentSHA256 != "" {
+		setHeaders(headers, HEADER_SHA256, []string{input.ContentSHA256}, isObs)
 	}
 
 	if input.ContentLength > 0 {
@@ -386,6 +439,9 @@ func (input ModifyObjectInput) trans(isObs bool) (params map[string]string, head
 }
 
 func (input CopyObjectInput) prepareReplaceHeaders(headers map[string][]string) {
+	if input.ContentType != "" {
+		headers[HEADER_CONTENT_TYPE] = []string{input.ContentType}
+	}
 	if input.CacheControl != "" {
 		headers[HEADER_CACHE_CONTROL] = []string{input.CacheControl}
 	}
@@ -398,11 +454,11 @@ func (input CopyObjectInput) prepareReplaceHeaders(headers map[string][]string) 
 	if input.ContentLanguage != "" {
 		headers[HEADER_CONTENT_LANGUAGE] = []string{input.ContentLanguage}
 	}
-	if input.ContentType != "" {
-		headers[HEADER_CONTENT_TYPE] = []string{input.ContentType}
-	}
+	// 这里为了兼容老版本，默认以Expire值为准，但如果Expires没有，则以HttpExpires为准。
 	if input.Expires != "" {
-		headers[HEADER_EXPIRES] = []string{input.Expires}
+		headers[HEADER_EXPIRES_CAMEL] = []string{input.Expires}
+	} else if input.HttpExpires != "" {
+		headers[HEADER_EXPIRES_CAMEL] = []string{input.HttpExpires}
 	}
 }
 
@@ -482,5 +538,29 @@ func (input RenameFolderInput) trans(isObs bool) (params map[string]string, head
 	if requestPayer := string(input.RequestPayer); requestPayer != "" {
 		headers[HEADER_REQUEST_PAYER] = []string{requestPayer}
 	}
+	return
+}
+
+func (input SetDirAccesslabelInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceAccesslabel): ""}
+
+	accesslabelJson, err := TransToJSON(input.Accesslabel)
+	if err != nil {
+		return
+	}
+	json := make([]string, 0, 2)
+	json = append(json, fmt.Sprintf("{\"accesslabel\": %s}", accesslabelJson))
+	data = strings.Join(json, "")
+
+	return
+}
+
+func (input GetDirAccesslabelInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceAccesslabel): ""}
+	return
+}
+
+func (input DeleteDirAccesslabelInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
+	params = map[string]string{string(SubResourceAccesslabel): ""}
 	return
 }

--- a/openstack/obs/trait_part.go
+++ b/openstack/obs/trait_part.go
@@ -52,6 +52,21 @@ func (input InitiateMultipartUploadInput) trans(isObs bool) (params map[string]s
 	if input.ContentType != "" {
 		headers[HEADER_CONTENT_TYPE_CAML] = []string{input.ContentType}
 	}
+	if input.ContentEncoding != "" {
+		headers[HEADER_CONTENT_ENCODING_CAMEL] = []string{input.ContentEncoding}
+	}
+	if input.CacheControl != "" {
+		headers[HEADER_CACHE_CONTROL_CAMEL] = []string{input.CacheControl}
+	}
+	if input.ContentDisposition != "" {
+		headers[HEADER_CONTENT_DISPOSITION_CAMEL] = []string{input.ContentDisposition}
+	}
+	if input.ContentLanguage != "" {
+		headers[HEADER_CONTENT_LANGUAGE_CAMEL] = []string{input.ContentLanguage}
+	}
+	if input.HttpExpires != "" {
+		headers[HEADER_EXPIRES_CAMEL] = []string{input.HttpExpires}
+	}
 	params[string(SubResourceUploads)] = ""
 	if input.EncodingType != "" {
 		params["encoding-type"] = input.EncodingType
@@ -62,9 +77,12 @@ func (input InitiateMultipartUploadInput) trans(isObs bool) (params map[string]s
 func (input UploadPartInput) trans(isObs bool) (params map[string]string, headers map[string][]string, data interface{}, err error) {
 	params = map[string]string{"uploadId": input.UploadId, "partNumber": IntToString(input.PartNumber)}
 	headers = make(map[string][]string)
-	setSseHeader(headers, input.SseHeader, true, isObs)
+	setSseHeader(headers, input.SseHeader, true, false, isObs)
 	if input.ContentMD5 != "" {
 		headers[HEADER_MD5_CAMEL] = []string{input.ContentMD5}
+	}
+	if input.ContentSHA256 != "" {
+		setHeaders(headers, HEADER_SHA256, []string{input.ContentSHA256}, isObs)
 	}
 	if input.Body != nil {
 		data = input.Body
@@ -108,8 +126,10 @@ func (input CopyPartInput) trans(isObs bool) (params map[string]string, headers 
 	if input.CopySourceRangeStart >= 0 && input.CopySourceRangeEnd > input.CopySourceRangeStart {
 		setHeaders(headers, HEADER_COPY_SOURCE_RANGE, []string{fmt.Sprintf("bytes=%d-%d", input.CopySourceRangeStart, input.CopySourceRangeEnd)}, isObs)
 	}
-
-	setSseHeader(headers, input.SseHeader, true, isObs)
+	if input.CopySourceRange != "" {
+		setHeaders(headers, HEADER_COPY_SOURCE_RANGE, []string{input.CopySourceRange}, isObs)
+	}
+	setSseHeader(headers, input.SseHeader, true, false, isObs)
 	if input.SourceSseHeader != nil {
 		if sseCHeader, ok := input.SourceSseHeader.(SseCHeader); ok {
 			setHeaders(headers, HEADER_SSEC_COPY_SOURCE_ENCRYPTION, []string{sseCHeader.GetEncryption()}, isObs)

--- a/openstack/obs/transfer.go
+++ b/openstack/obs/transfer.go
@@ -97,6 +97,9 @@ func (task *uploadPartTask) Run() interface{} {
 	input.SourceFile = task.SourceFile
 	input.Offset = task.Offset
 	input.PartSize = task.PartSize
+	input.ContentMD5 = task.ContentMD5
+	input.ContentSHA256 = task.ContentSHA256
+
 	extensions := task.extensions
 
 	var output *UploadPartOutput
@@ -140,7 +143,7 @@ func updateCheckpointFile(fc interface{}, checkpointFilePath string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(checkpointFilePath, result, 0666)
+	err = ioutil.WriteFile(checkpointFilePath, result, 0640)
 	return err
 }
 
@@ -180,7 +183,14 @@ func getCheckpointFile(ufc *UploadCheckpoint, uploadFileStat os.FileInfo, input 
 func prepareUpload(ufc *UploadCheckpoint, uploadFileStat os.FileInfo, input *UploadFileInput, obsClient *ObsClient, extensions []extensionOptions) error {
 	initiateInput := &InitiateMultipartUploadInput{}
 	initiateInput.ObjectOperationInput = input.ObjectOperationInput
-	initiateInput.ContentType = input.ContentType
+	initiateInput.HttpHeader = HttpHeader{
+		CacheControl:       input.CacheControl,
+		ContentEncoding:    input.ContentEncoding,
+		ContentType:        input.ContentType,
+		ContentDisposition: input.ContentDisposition,
+		ContentLanguage:    input.ContentLanguage,
+		HttpExpires:        input.HttpExpires,
+	}
 	initiateInput.EncodingType = input.EncodingType
 	var output *InitiateMultipartUploadOutput
 	var err error
@@ -531,7 +541,7 @@ func (task *downloadPartTask) Run() interface{} {
 	getObjectInput.IfUnmodifiedSince = task.IfUnmodifiedSince
 	getObjectInput.RangeStart = task.RangeStart
 	getObjectInput.RangeEnd = task.RangeEnd
-
+	getObjectInput.Range = fmt.Sprintf("bytes=%d-%d", getObjectInput.RangeStart, getObjectInput.RangeEnd)
 	var output *GetObjectOutput
 	var err error
 	if len(task.extensions) != 0 {
@@ -634,7 +644,7 @@ func sliceObject(objectSize, partSize int64, dfc *DownloadCheckpoint) {
 }
 
 func createFile(tempFileURL string, fileSize int64) error {
-	fd, err := syscall.Open(tempFileURL, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	fd, err := syscall.Open(tempFileURL, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
 	if err != nil {
 		doLog(LEVEL_WARN, "Failed to open temp download file [%s].", tempFileURL)
 		return err
@@ -671,7 +681,7 @@ func prepareTempFile(tempFileURL string, fileSize int64) error {
 	if err == nil {
 		return nil
 	}
-	fd, err := os.OpenFile(tempFileURL, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	fd, err := os.OpenFile(tempFileURL, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
 	if err != nil {
 		doLog(LEVEL_ERROR, "Failed to open temp download file [%s].", tempFileURL)
 		return err
@@ -780,7 +790,7 @@ func (obsClient ObsClient) resumeDownload(input *DownloadFileInput, extensions [
 }
 
 func updateDownloadFile(filePath string, rangeStart int64, output *GetObjectOutput) error {
-	fd, err := os.OpenFile(filePath, os.O_WRONLY, 0666)
+	fd, err := os.OpenFile(filePath, os.O_WRONLY, 0640)
 	if err != nil {
 		doLog(LEVEL_ERROR, "Failed to open file [%s].", filePath)
 		return err

--- a/openstack/obs/type.go
+++ b/openstack/obs/type.go
@@ -82,6 +82,9 @@ const (
 	// SubResourceEncryption subResource value: encryption
 	SubResourceEncryption SubResourceType = "encryption"
 
+	// SubResourceReplication subResource value: replication
+	SubResourceReplication SubResourceType = "replication"
+
 	// SubResourceTagging subResource value: tagging
 	SubResourceTagging SubResourceType = "tagging"
 
@@ -223,6 +226,14 @@ const (
 
 	// GroupLogDelivery grantee uri type: LogDelivery
 	GroupLogDelivery GroupUriType = "LogDelivery"
+)
+
+// EnabledType defines a common status type
+type EnabledType string
+
+const (
+	Enabled  EnabledType = "Enabled"
+	Disabled EnabledType = "Disabled"
 )
 
 // VersioningStatusType defines bucket version status

--- a/openstack/obs/type.go
+++ b/openstack/obs/type.go
@@ -82,9 +82,6 @@ const (
 	// SubResourceEncryption subResource value: encryption
 	SubResourceEncryption SubResourceType = "encryption"
 
-	// SubResourceReplication subResource value: replication
-	SubResourceReplication SubResourceType = "replication"
-
 	// SubResourceTagging subResource value: tagging
 	SubResourceTagging SubResourceType = "tagging"
 
@@ -120,6 +117,18 @@ const (
 
 	// SubResourceMirrorBackToSource subResource value: mirrorBackToSource
 	SubResourceMirrorBackToSource SubResourceType = "mirrorBackToSource"
+
+	// SubResourceMirrorBackToSource subResource value: mirrorBackToSource
+	SubResourceAccesslabel SubResourceType = "x-obs-accesslabel"
+
+	// SubResourceMirrorBackToSource subResource value: publicAccessBlock
+	SubResourcePublicAccessBlock SubResourceType = "publicAccessBlock"
+
+	// SubResourcePublicBucketStatus subResource value: bucketStatus
+	SubResourceBucketPublicStatus SubResourceType = "bucketStatus"
+
+	// SubResourcePublicPolicyStatus subResource value: policyStatus
+	SubResourceBucketPolicyPublicStatus SubResourceType = "policyStatus"
 )
 
 // objectKeyType defines the objectKey value
@@ -163,6 +172,9 @@ const (
 
 	//StorageClassDeepArchive storage class: DEEP_ARCHIVE
 	StorageClassDeepArchive StorageClassType = "DEEP_ARCHIVE"
+
+	//StorageClassIntelligentTiering storage class: INTELLIGENT_TIERING
+	StorageClassIntelligentTiering StorageClassType = "INTELLIGENT_TIERING"
 
 	storageClassStandardIA StorageClassType = "STANDARD_IA"
 	storageClassGlacier    StorageClassType = "GLACIER"
@@ -211,14 +223,6 @@ const (
 
 	// GroupLogDelivery grantee uri type: LogDelivery
 	GroupLogDelivery GroupUriType = "LogDelivery"
-)
-
-// EnabledType defines a common status type
-type EnabledType string
-
-const (
-	Enabled  EnabledType = "Enabled"
-	Disabled EnabledType = "Disabled"
 )
 
 // VersioningStatusType defines bucket version status

--- a/openstack/obs/util.go
+++ b/openstack/obs/util.go
@@ -122,9 +122,9 @@ func FormatUtcNow(format string) string {
 	return time.Now().UTC().Format(format)
 }
 
-// FormatNow gets a textual representation of the format time value
-func FormatNow(format string) string {
-	return time.Now().Format(format)
+// FormatNowWithLoc gets a textual representation of the format time value with loc
+func FormatNowWithLoc(format string, loc *time.Location) string {
+	return time.Now().In(loc).Format(format)
 }
 
 // FormatUtcToRfc1123 gets a textual representation of the RFC1123 format time value
@@ -183,6 +183,19 @@ func Base64Md5(value []byte) string {
 	return Base64Encode(Md5(value))
 }
 
+// Base64Md5OrSha256 returns the md5 or sha256 value of input with Base64Encode
+func Base64Md5OrSha256(value []byte, enableSha256 bool) string {
+	if enableSha256 {
+		return Base64Sha256(value)
+	}
+	return Base64Md5(value)
+}
+
+// Base64Sha256 returns the sha256 value of input with Base64Encode
+func Base64Sha256(value []byte) string {
+	return Base64Encode(Sha256Hash(value))
+}
+
 // Sha256Hash returns sha256 checksum
 func Sha256Hash(value []byte) []byte {
 	hash := sha256.New()
@@ -215,6 +228,14 @@ func TransToXml(value interface{}) ([]byte, error) {
 		return []byte{}, nil
 	}
 	return xml.Marshal(value)
+}
+
+// TransToJSON wrapper of json.Marshal
+func TransToJSON(value interface{}) ([]byte, error) {
+	if value == nil {
+		return []byte{}, nil
+	}
+	return json.Marshal(value)
 }
 
 // Hex wrapper of hex.EncodeToString
@@ -624,4 +645,23 @@ func GetReaderLen(reader io.Reader) (int64, error) {
 		err = fmt.Errorf("can't get reader content length,unkown reader type")
 	}
 	return contentLength, err
+}
+
+func validateLength(value int, minLen int, maxLen int, fieldName string) error {
+	if minLen > maxLen {
+		return fmt.Errorf("Min Value can not be greater than Max Value")
+	}
+	if minLen == maxLen && value != minLen {
+		return fmt.Errorf("%s length must be %d characters. (value len: %d)", fieldName, maxLen, value)
+	}
+	if value < minLen || value > maxLen {
+		return fmt.Errorf("%s length must be between %d and %d characters. (value len: %d)", fieldName, minLen, maxLen, value)
+	}
+	return nil
+}
+
+func updateVersionId(objectTaggingOutput *ObjectTaggingOutput) {
+	if versionID, ok := objectTaggingOutput.ResponseHeaders[HEADER_VERSION_ID]; ok && len(versionID) > 0 {
+		objectTaggingOutput.VersionId = versionID[0]
+	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
  will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

There are four commits:
- Cover your local obs sdk package with the official repository and commit changes.
- Cherry-pick local change commit records, and handling conflicts.
- Update the Version
- Fix sync lock warning,  The pipeline failed cause the config contains sync field, and used value passing.

Test case:
```
./scripts/coverage.sh -o obs -f TestAcc
Prepare to calculate the coverage the following command:
TF_ACC=1 go test "./huaweicloud/services/acceptance/obs" -v -coverprofile="./huaweicloud/services/acceptance/obs/obs_coverage.cov" -coverpkg="./huaweicloud/services/obs" -run TestAcc -timeout 360m -parallel 10
=== RUN   TestAccObsBucketObjectDataSource_content
=== PAUSE TestAccObsBucketObjectDataSource_content
=== RUN   TestAccObsBucketObjectDataSource_source
=== PAUSE TestAccObsBucketObjectDataSource_source
=== RUN   TestAccObsBucketObjectDataSource_allParams
=== PAUSE TestAccObsBucketObjectDataSource_allParams
=== RUN   TestAccDataSourceObsBuckets_basic
=== PAUSE TestAccDataSourceObsBuckets_basic
=== RUN   TestAccOBSBucketAcl_basic
=== PAUSE TestAccOBSBucketAcl_basic
=== RUN   TestAccOBSBucketObjectAcl_basic
=== PAUSE TestAccOBSBucketObjectAcl_basic
=== RUN   TestAccOBSBucketObjectAcl_checkError
=== PAUSE TestAccOBSBucketObjectAcl_checkError
=== RUN   TestAccObsBucketObject_source
=== PAUSE TestAccObsBucketObject_source
=== RUN   TestAccObsBucketObject_content
=== PAUSE TestAccObsBucketObject_content
=== RUN   TestAccObsBucketPolicy_basic
=== PAUSE TestAccObsBucketPolicy_basic
=== RUN   TestAccObsBucketPolicy_update
=== PAUSE TestAccObsBucketPolicy_update
=== RUN   TestAccObsBucketPolicy_s3
=== PAUSE TestAccObsBucketPolicy_s3
=== RUN   TestAccObsBucketReplication_basic
=== PAUSE TestAccObsBucketReplication_basic
=== RUN   TestAccObsBucket_basic
=== PAUSE TestAccObsBucket_basic
=== RUN   TestAccObsBucket_withEpsId
=== PAUSE TestAccObsBucket_withEpsId
=== RUN   TestAccObsBucket_multiAZ
=== PAUSE TestAccObsBucket_multiAZ
=== RUN   TestAccObsBucket_parallelFS
=== PAUSE TestAccObsBucket_parallelFS
=== RUN   TestAccObsBucket_encryption
=== PAUSE TestAccObsBucket_encryption
=== RUN   TestAccObsBucket_versioning
=== PAUSE TestAccObsBucket_versioning
=== RUN   TestAccObsBucket_logging
=== PAUSE TestAccObsBucket_logging
=== RUN   TestAccObsBucket_quota
=== PAUSE TestAccObsBucket_quota
=== RUN   TestAccObsBucket_lifecycle
=== PAUSE TestAccObsBucket_lifecycle
=== RUN   TestAccObsBucket_website
=== PAUSE TestAccObsBucket_website
=== RUN   TestAccObsBucket_cors
=== PAUSE TestAccObsBucket_cors
=== RUN   TestAccObsBucket_userDomainNames
=== PAUSE TestAccObsBucket_userDomainNames
=== CONT  TestAccObsBucketObjectDataSource_content
=== CONT  TestAccObsBucket_withEpsId
=== CONT  TestAccObsBucket_quota
=== CONT  TestAccObsBucketPolicy_s3
=== CONT  TestAccObsBucket_encryption
=== CONT  TestAccObsBucket_cors
=== CONT  TestAccObsBucketObject_source
=== CONT  TestAccObsBucket_userDomainNames
=== CONT  TestAccObsBucketReplication_basic
=== CONT  TestAccObsBucket_basic
--- PASS: TestAccObsBucket_quota (37.96s)
=== CONT  TestAccObsBucketPolicy_basic
--- PASS: TestAccObsBucket_cors (40.34s)
=== CONT  TestAccObsBucketPolicy_update
--- PASS: TestAccObsBucketPolicy_s3 (41.57s)
=== CONT  TestAccOBSBucketAcl_basic
--- PASS: TestAccObsBucketObjectDataSource_content (59.90s)
=== CONT  TestAccOBSBucketObjectAcl_checkError
--- PASS: TestAccObsBucketObject_source (72.08s)
=== CONT  TestAccOBSBucketObjectAcl_basic
--- PASS: TestAccObsBucket_basic (73.42s)
=== CONT  TestAccObsBucketObjectDataSource_allParams
--- PASS: TestAccObsBucketPolicy_basic (37.94s)
=== CONT  TestAccDataSourceObsBuckets_basic
--- PASS: TestAccOBSBucketObjectAcl_checkError (21.22s)
=== CONT  TestAccObsBucket_parallelFS
--- PASS: TestAccObsBucket_userDomainNames (90.08s)
=== CONT  TestAccObsBucket_website
--- PASS: TestAccObsBucketReplication_basic (98.24s)
=== CONT  TestAccObsBucket_logging
--- PASS: TestAccObsBucketPolicy_update (60.06s)
=== CONT  TestAccObsBucket_lifecycle
--- PASS: TestAccOBSBucketAcl_basic (62.71s)
=== CONT  TestAccObsBucketObjectDataSource_source
--- PASS: TestAccObsBucket_parallelFS (31.66s)
=== CONT  TestAccObsBucketObject_content
--- PASS: TestAccObsBucket_withEpsId (119.86s)
=== CONT  TestAccObsBucket_versioning
--- PASS: TestAccObsBucket_website (30.87s)
=== CONT  TestAccObsBucket_multiAZ
--- PASS: TestAccDataSourceObsBuckets_basic (46.10s)
--- PASS: TestAccObsBucketObjectDataSource_allParams (55.55s)
--- PASS: TestAccObsBucket_lifecycle (31.30s)
--- PASS: TestAccObsBucket_logging (35.94s)
--- PASS: TestAccOBSBucketObjectAcl_basic (62.44s)
--- PASS: TestAccObsBucketObject_content (28.65s)
--- PASS: TestAccObsBucket_multiAZ (24.98s)
--- PASS: TestAccObsBucketObjectDataSource_source (44.62s)
--- PASS: TestAccObsBucket_encryption (153.93s)
--- PASS: TestAccObsBucket_versioning (38.00s)
PASS
coverage: 79.2% of statements in ./huaweicloud/services/obs
ok      github.com/huaweicloud/terraform-provider-huaweicloud/huaweicloud/services/acceptance/obs       157.987s        coverage: 79.2% of statements in ./huaweicloud/services/obs
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note.
  If no release note is required, just write `NONE`.
-->

```release-note
```
